### PR TITLE
Unify subagent prompt envelopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,9 @@ child context is clearer than starting over.
 
 For original fresh runs, resume reloads current prompt resources from
 the recorded cwd, including named-agent `agentsMd` and `skills`
-controls. For original fork runs, resume uses fork-style resources and
-sends `message` as plain user text, because any named-agent body is
-already in the child transcript.
+controls. For original fork runs, resume uses fork-style resources.
+All resume calls send `message` as plain user text, because the
+initial `subagent` prompt envelope is already in the child transcript.
 
 ### `subagent_list({ cwd? })`
 
@@ -197,13 +197,16 @@ empty bodies are rejected.
 Discovery is non-recursive and ignores hidden files, nested
 directories, uppercase `.MD`, and `*.chain.md` files.
 
-Fresh default-mode runs do not load markdown agents, suppress
-`AGENTS.md` / `CLAUDE.md` context files, and keep normal skills. Named
-fresh runs append the agent body to the child system prompt;
-`agentsMd` controls context-file loading, and `skills` controls skill
-loading. Fork runs ignore those frontmatter resource controls and
-place any named-agent body in the user prompt instead of the system
-prompt.
+Every initial `subagent` call sends the child a single XML-style user
+prompt envelope with subagent context and the task. Named agents add a
+sanitized `<name-agent>` block containing the markdown body between
+that context and the task. Fresh default-mode runs do not load
+markdown agents, suppress `AGENTS.md` / `CLAUDE.md` context files, and
+keep normal skills. For named fresh runs, `agentsMd` controls
+context-file loading and `skills` controls skill loading; the agent
+body stays in the user prompt envelope rather than the child system
+prompt. Fork runs ignore those frontmatter resource controls but use
+the same user prompt envelope for omitted and named agents.
 
 ## Artifacts and progress
 
@@ -331,6 +334,6 @@ npm run smoke:registration
 ```
 
 The model-facing tool labels, descriptions, schema descriptions,
-guidelines, and fork prompt template live in
-`src/tool-prompts.ts`. Keep that file, `src/index.ts`, and this README
-in sync when the tool contract changes.
+guidelines, and prompt envelope helpers live in `src/tool-prompts.ts`.
+Keep that file, `src/index.ts`, and this README in sync when the tool
+contract changes.

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -21,7 +21,7 @@ import { QueuedActivityLogWriter, appendActivityLogFinished, appendActivityLogSt
 import { appendManifestRecord, findLatestEpisodeStartedRecordBySessionFile, readManifestRecords, requireUniqueStartedRecordBySessionId, type DegradedAppendOptions, type EpisodeStartedManifestRecord, type StartedManifestRecord } from "./manifest.js";
 import { errorHeading, namedAgentSelection, omittedAgentSelection, renderSubagentInterrupted, renderSubagentProgress, renderSubagentRecoverableError, renderSubagentResult } from "./render.js";
 import { assertDirectoryExists, manifestPathForSubagentsRoot, resolveFreshCwd, resolveSubagentsRoot, type SubagentsRoot } from "./sessions.js";
-import { namedForkPrompt } from "./tool-prompts.js";
+import { buildSubagentPromptEnvelope } from "./tool-prompts.js";
 import { OMITTED_AGENT_LABEL, type AgentSelection, type MarkdownAgent, type SubagentContextMode, type SubagentContextUsage, type SubagentParams, type SubagentResumeParams, type SubagentToolDetails, type TextToolResult } from "./types.js";
 
 type DefaultResourceLoaderOptions = ConstructorParameters<typeof DefaultResourceLoader>[0];
@@ -159,8 +159,6 @@ export function buildFreshResourceLoaderOptions(profile: SubagentPromptProfile, 
   if (options.settingsManager) loaderOptions.settingsManager = options.settingsManager;
   if (options.extensionFactories && options.extensionFactories.length > 0) loaderOptions.extensionFactories = options.extensionFactories;
   if (profile.agentsMd === "none") loaderOptions.noContextFiles = true;
-  if (profile.agentBody) loaderOptions.appendSystemPromptOverride = (base) => [...base, profile.agentBody ?? ""];
-
   if (profile.skills === "none") {
     loaderOptions.noSkills = true;
   } else if (typeof profile.skills === "object") {
@@ -199,9 +197,10 @@ function createProjectTrustedSettingsManager(cwd: string, agentDir: string): Pro
   return SettingsManager.create(cwd, agentDir, { projectTrusted: true });
 }
 
-export function buildForkPrompt(profile: SubagentPromptProfile, task: string): string {
-  if (profile.selection.kind === "omitted") return task;
-  return namedForkPrompt(profile.agentName, profile.agentBody, task);
+export function buildInitialSubagentPrompt(profile: SubagentPromptProfile, context: SubagentContextMode, task: string, parentDepth: number): string {
+  if (profile.selection.kind === "omitted") return buildSubagentPromptEnvelope({ context, task, parentDepth });
+  if (profile.agentBody === undefined) return buildSubagentPromptEnvelope({ context, task, parentDepth, agentName: profile.agentName });
+  return buildSubagentPromptEnvelope({ context, task, parentDepth, agentName: profile.agentName, agentBody: profile.agentBody });
 }
 
 export async function runSubagent(
@@ -498,7 +497,7 @@ async function prepareFreshRun(
     agentDir,
     settingsManager,
     resourceLoader,
-    userPrompt: params.task,
+    userPrompt: buildInitialSubagentPrompt(profile, "fresh", params.task, parentDepth),
     inheritParentModel: true,
   };
 }
@@ -546,7 +545,7 @@ async function prepareForkRun(
     agentDir,
     settingsManager,
     resourceLoader,
-    userPrompt: buildForkPrompt(profile, params.task),
+    userPrompt: buildInitialSubagentPrompt(profile, "fork", params.task, parentDepth),
     currentLeafId,
     sourceSessionManager,
     inheritParentModel: false,

--- a/src/tool-prompts.ts
+++ b/src/tool-prompts.ts
@@ -49,6 +49,41 @@ export const TOOL_PROMPTS = {
   },
 } as const;
 
-export function namedForkPrompt(agentName: string, agentBody: string | undefined, task: string): string {
-  return `Subagent instructions from \`${agentName}\`:\n${agentBody ?? ""}\n\nTask:\n${task}`;
+export interface SubagentPromptEnvelopeOptions {
+  context: "fresh" | "fork";
+  task: string;
+  parentDepth: number;
+  agentName?: string;
+  agentBody?: string;
+}
+
+export function buildSubagentPromptEnvelope(options: SubagentPromptEnvelopeOptions): string {
+  const contextLine = options.context === "fresh"
+    ? "You are a child subagent. You start without the parent conversation."
+    : "You are a child subagent. You start from a copy of the parent conversation.";
+  const depthLine = subagentDepthLine(options.parentDepth);
+  const parts = [
+    `<subagent-context>\n${contextLine}\n${depthLine}\n</subagent-context>`,
+  ];
+
+  if (options.agentName !== undefined) {
+    const tag = subagentAgentTagName(options.agentName);
+    parts.push(`<${tag}>\n${options.agentBody ?? ""}\n</${tag}>`);
+  }
+
+  parts.push(`<task>\n${options.task}\n</task>`);
+  return parts.join("\n\n");
+}
+
+export function subagentAgentTagName(agentName: string): string {
+  let sanitized = agentName.toLowerCase().replace(/[^a-z0-9_-]+/g, "-").replace(/^-+|-+$/g, "");
+  if (!sanitized) sanitized = "agent";
+  if (!/^[a-z]/.test(sanitized)) sanitized = `agent-${sanitized}`;
+  return `${sanitized}-agent`;
+}
+
+function subagentDepthLine(parentDepth: number): string {
+  if (parentDepth <= 0) return "You are the first subagent in this tree.";
+  if (parentDepth === 1) return "You have one parent subagent above you in this tree.";
+  return `You have ${parentDepth} parent subagents above you in this tree.`;
 }

--- a/test/profiles.test.ts
+++ b/test/profiles.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { buildForkPrompt, buildForkResourceLoaderOptions, buildFreshResourceLoaderOptions, omittedSubagentProfile, namedSubagentProfile } from "../src/runner.js";
+import { buildForkResourceLoaderOptions, buildFreshResourceLoaderOptions, buildInitialSubagentPrompt, omittedSubagentProfile, namedSubagentProfile } from "../src/runner.js";
+import { subagentAgentTagName } from "../src/tool-prompts.js";
 import type { MarkdownAgent } from "../src/types.js";
 import type { Skill } from "@earendil-works/pi-coding-agent";
 
@@ -27,13 +28,13 @@ describe("subagent prompt-resource profiles", () => {
     expect(options.appendSystemPromptOverride).toBeUndefined();
   });
 
-  it("appends named agent bodies without discarding normal append-prompt resources", () => {
+  it("keeps named-agent fresh mode resource controls out of the system prompt", () => {
     const profile = namedSubagentProfile(namedAgent);
     const options = buildFreshResourceLoaderOptions(profile, { cwd: "/repo", agentDir: "/agent" });
 
     expect(profile.selection).toEqual({ kind: "named", name: "reviewer", agentFile: namedAgent.filePath });
     expect(options.noContextFiles).toBe(true);
-    expect(options.appendSystemPromptOverride?.(["base append"])).toEqual(["base append", "Review carefully."]);
+    expect(options.appendSystemPromptOverride).toBeUndefined();
   });
 
   it("leaves normal context-file discovery enabled for agentsMd auto", () => {
@@ -69,15 +70,56 @@ describe("subagent prompt-resource profiles", () => {
   });
 });
 
-describe("fork prompt/resource profiles", () => {
-  it("uses the raw task for omitted-agent fork prompts", () => {
-    expect(buildForkPrompt(omittedSubagentProfile(), "answer from history")).toBe("answer from history");
+describe("initial subagent prompt envelopes", () => {
+  it("wraps omitted-agent fresh prompts with root context", () => {
+    expect(buildInitialSubagentPrompt(omittedSubagentProfile(), "fresh", "answer from scratch", 0)).toBe(`<subagent-context>
+You are a child subagent. You start without the parent conversation.
+You are the first subagent in this tree.
+</subagent-context>
+
+<task>
+answer from scratch
+</task>`);
   });
 
-  it("prefixes named-agent fork prompts as user-message text", () => {
-    expect(buildForkPrompt(namedSubagentProfile(namedAgent), "inspect the branch")).toBe("Subagent instructions from `reviewer`:\nReview carefully.\n\nTask:\ninspect the branch");
+  it("wraps omitted-agent fork prompts with fork context", () => {
+    expect(buildInitialSubagentPrompt(omittedSubagentProfile(), "fork", "answer from history", 0)).toBe(`<subagent-context>
+You are a child subagent. You start from a copy of the parent conversation.
+You are the first subagent in this tree.
+</subagent-context>
+
+<task>
+answer from history
+</task>`);
   });
 
+  it("includes named-agent markdown bodies in a sanitized user-prompt block", () => {
+    expect(buildInitialSubagentPrompt(namedSubagentProfile(namedAgent), "fork", "inspect the branch", 1)).toBe(`<subagent-context>
+You are a child subagent. You start from a copy of the parent conversation.
+You have one parent subagent above you in this tree.
+</subagent-context>
+
+<reviewer-agent>
+Review carefully.
+</reviewer-agent>
+
+<task>
+inspect the branch
+</task>`);
+  });
+
+  it("sanitizes named-agent XML-style tags", () => {
+    expect(subagentAgentTagName("reviewer")).toBe("reviewer-agent");
+    expect(subagentAgentTagName("code.review")).toBe("code-review-agent");
+    expect(subagentAgentTagName("2nd-pass")).toBe("agent-2nd-pass-agent");
+  });
+
+  it("describes deeper nested subagents naturally", () => {
+    expect(buildInitialSubagentPrompt(omittedSubagentProfile(), "fresh", "deep task", 3)).toContain("You have 3 parent subagents above you in this tree.");
+  });
+});
+
+describe("fork resource profiles", () => {
   it("keeps fork resource loading free of subagent prompt-resource overrides", () => {
     const options = buildForkResourceLoaderOptions({ cwd: "/repo", agentDir: "/agent" });
 

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -61,6 +61,22 @@ function expectNoModelVisiblePaths(text: string): void {
   expect(text).not.toMatch(/\.jsonl|\.subagents|Activity log|stack|runId|episodeId/i);
 }
 
+function expectedPromptEnvelope(context: "fresh" | "fork", task: string, options: { parentDepth?: number; agentName?: string; agentBody?: string } = {}): string {
+  const contextLine = context === "fresh"
+    ? "You are a child subagent. You start without the parent conversation."
+    : "You are a child subagent. You start from a copy of the parent conversation.";
+  const parentDepth = options.parentDepth ?? 0;
+  const depthLine = parentDepth === 0
+    ? "You are the first subagent in this tree."
+    : parentDepth === 1
+      ? "You have one parent subagent above you in this tree."
+      : `You have ${parentDepth} parent subagents above you in this tree.`;
+  const parts = [`<subagent-context>\n${contextLine}\n${depthLine}\n</subagent-context>`];
+  if (options.agentName !== undefined) parts.push(`<${options.agentName}-agent>\n${options.agentBody ?? ""}\n</${options.agentName}-agent>`);
+  parts.push(`<task>\n${task}\n</task>`);
+  return parts.join("\n\n");
+}
+
 function expectInterruptedCapsule(text: string, sessionId: string, heading = "## Subagent interrupted"): void {
   expect(text).toContain(heading);
   expect(text).toContain("No final answer was produced.");
@@ -779,16 +795,17 @@ describe("subagent runner", () => {
     const oldAgentPath = path.join(root, "old-agents", "reviewer.md");
     await writeChildSessionHeader(childSession, "named-fresh-session", cwd);
     await writeManifestRecord(parentSession, startedManifestRecord({ sessionId: "named-fresh-session", agent: "reviewer", cwd, context: "fresh", sessionFile: childSession, agentFile: oldAgentPath }));
-    const { deps } = fakeDeps(root);
+    const { deps, fakeSession } = fakeDeps(root);
 
     const result = await runSubagentResume({ sessionId: "named-fresh-session", message: "continue review" }, undefined, undefined, fakeContext(cwd, parentSession), { deps });
 
     expectSubagentResult(result, "## Subagent reviewer result");
     const loaderCalls = (deps.createResourceLoader as unknown as { mock: { calls: Array<[Record<string, unknown>]> } }).mock.calls;
     const loaderOptions = loaderCalls[0]?.[0];
+    expect(fakeSession.promptedWith).toBe("continue review");
     expect(loaderOptions).toMatchObject({ cwd, agentDir: path.join(root, "agent"), noSkills: true });
     expect(loaderOptions?.noContextFiles).toBeUndefined();
-    expect((loaderOptions?.appendSystemPromptOverride as (base: string[]) => string[])(["base"])).toEqual(["base", "Fresh reviewer body."]);
+    expect(loaderOptions?.appendSystemPromptOverride).toBeUndefined();
     const manifest = await readManifestRecords(`${parentSession}.subagents/manifest.jsonl`);
     expect(manifest).toContainEqual(expect.objectContaining({ type: "resume_started", episodeId: "run-1", sessionId: "named-fresh-session", agentFile: agentPath }));
     expect(manifest).not.toContainEqual(expect.objectContaining({ type: "resume_started", agentFile: oldAgentPath }));
@@ -1001,7 +1018,7 @@ describe("subagent runner", () => {
 
     const result = await runSubagent({ task: "answer briefly" }, undefined, (partial) => updates.push(partial), fakeContext(cwd, parentSession), { deps });
 
-    expect(fakeSession.promptedWith).toBe("answer briefly");
+    expect(fakeSession.promptedWith).toBe(expectedPromptEnvelope("fresh", "answer briefly"));
     expectSubagentResult(result);
     expect(result.content[0]?.text).not.toContain(".subagents.md");
     expect(result.content[0]?.text).not.toContain(".subagents");
@@ -1206,10 +1223,11 @@ describe("subagent runner", () => {
     await mkdir(path.dirname(agentPath), { recursive: true });
     await writeFile(agentPath, "---\ndescription: Literal named subagent\n---\n\nNamed body.\n", "utf8");
     const parentSession = path.join(root, "sessions", "parent.jsonl");
-    const { deps } = fakeDeps(root);
+    const { deps, fakeSession } = fakeDeps(root);
 
     const result = await runSubagent({ agent: "subagent", task: "use the named file" }, undefined, undefined, fakeContext(cwd, parentSession), { deps });
 
+    expect(fakeSession.promptedWith).toBe(expectedPromptEnvelope("fresh", "use the named file", { agentName: "subagent", agentBody: "Named body." }));
     expectSubagentResult(result, "## Subagent subagent result");
     const manifest = await readManifestRecords(`${parentSession}.subagents/manifest.jsonl`);
     expect(manifest[0]).toMatchObject({ type: "started", agent: "subagent", agentFile: agentPath });
@@ -1435,6 +1453,7 @@ describe("subagent runner", () => {
     const expectedActivityLog = expectedActivityLogForParentSession(parentSession);
     expect(manifest).toContainEqual(expect.objectContaining({ type: "started", episodeId: "run-2", parentEpisodeId: "run-1", activityLog: expectedActivityLog }));
     const activityText = await readFile(expectedActivityLog, "utf8");
+    expect(nested.fakeSession.promptedWith).toBe(expectedPromptEnvelope("fresh", "inner", { parentDepth: 1 }));
     expect(activityText).toContain("started subagent — episode run-1 — session:");
     expect(activityText).toContain("started subagent -> subagent — episode run-2 — session:");
     expect(activityText).toContain("completed subagent -> subagent — 0 turns — session:");
@@ -1591,14 +1610,14 @@ describe("subagent runner", () => {
     expect(deps.openSessionManager).toHaveBeenCalledWith(parentSession, `${parentSession}.subagents`);
     expect(forkManager.branchedFrom).toBe("leaf-current");
     expect(deps.createFreshSessionManager).not.toHaveBeenCalled();
-    expect(fakeSession.promptedWith).toBe("continue from here");
+    expect(fakeSession.promptedWith).toBe(expectedPromptEnvelope("fork", "continue from here"));
     expectSubagentResult(result);
 
     const manifest = await readManifestRecords(`${parentSession}.subagents/manifest.jsonl`);
     expect(manifest[0]).toMatchObject({ type: "started", episodeId: "run-1", parentEpisodeId: null, agent: "subagent", agentFile: null, cwd, context: "fork", sessionFile: childSession });
   });
 
-  it("runs named-agent fork prompts as user text without fresh resource overrides or model overrides", async () => {
+  it("runs named-agent fork prompt envelopes without fresh resource overrides or model overrides", async () => {
     const root = await tempRoot();
     const cwd = path.join(root, "project");
     const agentPath = path.join(cwd, ".pi", "agents", "reviewer.md");
@@ -1612,7 +1631,7 @@ describe("subagent runner", () => {
 
     const result = await runSubagent({ agent: "reviewer", task: "inspect the branch", context: "fork" }, undefined, undefined, fakeContext(cwd, parentSession, { model: { id: "parent-model" } }), { deps });
 
-    expect(fakeSession.promptedWith).toBe("Subagent instructions from `reviewer`:\nReview body.\n\nTask:\ninspect the branch");
+    expect(fakeSession.promptedWith).toBe(expectedPromptEnvelope("fork", "inspect the branch", { agentName: "reviewer", agentBody: "Review body." }));
     expectSubagentResult(result, "## Subagent reviewer result");
 
     const loaderCalls = (deps.createResourceLoader as unknown as { mock: { calls: Array<[Record<string, unknown>]> } }).mock.calls;


### PR DESCRIPTION
Subagents should not have to guess where their instructions are hidden. A named agent used to be system-prompt text in fresh sessions, but user-prompt text in forked sessions; omitted agents received no context at all. That made the prompt harder to inspect and made forked children easier to confuse with their parent.

This PR gives every new `subagent()` call the same small XML-style envelope. It tells the child whether it starts with or without the parent conversation, states its place in the subagent tree in natural language, and puts named-agent text in a visible `<reviewer-agent>`-style block before the `<task>`.

`subagent_resume` remains plain: a resumed session already has the original envelope in its transcript, so the follow-up should stay exactly what the user wrote.

Checks run:

- `npm test`
- `npm run typecheck`
- `npm run build`
