### PR TITLE
Add subagent model selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ run metadata, the child session ID, and the child's final answer.
 
 - Fresh child sessions for isolated work, or forked child sessions
   when the child should inherit the current conversation branch.
-- Named agents defined by simple markdown files with only three
-  frontmatter knobs: `description`, `agentsMd`, and `skills`.
+- Named agents defined by simple markdown files with four frontmatter
+  knobs: `description`, `model`, `agentsMd`, and `skills`.
+- Per-agent model defaults with an optional model override on each
+  `subagent` call.
 - Agent discovery for user-level and project-level markdown agents,
   including `subagent_list` for showing what is visible from a cwd.
 - Runtime status updates that report activity, turn counts, nested
@@ -38,7 +40,7 @@ workflow engine.
 The extension registers three tools:
 
 ```ts
-subagent({ agent?, task, context?, cwd? })
+subagent({ agent?, task, model?, context?, cwd? })
 subagent_resume({ sessionId, message })
 subagent_list({ cwd? })
 ```
@@ -53,17 +55,19 @@ The common calls are intentionally small:
 
 ```ts
 subagent({ task: "Inspect src/runner.ts and summarize the control flow." })
-subagent({ agent: "reviewer", task: "Review the changes in src/runner.ts." })
+subagent({ agent: "vision", task: "Read any screenshots or images and return their contents", model: "glm-5v-turbo" })
 subagent({ context: "fork", task: "Use the current conversation branch to check my last plan." })
 ```
 
 Fresh runs are independent child sessions. They can use files and
 tools in their cwd, but they do not see the current parent
 conversation, so put the needed background, paths, constraints, and
-desired output in `task`. Use `context: "fork"` only when the child
-should inherit a copy of the current conversation.
+desired output in `task`. Fresh calls do not forward images attached
+to the parent turn; include child-readable image paths in `task`.
+Use `context: "fork"` only when the child should inherit a copy of the
+current conversation, including images already present on that branch.
 
-### `subagent({ agent?, task, context?, cwd? })`
+### `subagent({ agent?, task, model?, context?, cwd? })`
 
 Runs one focused task in a child Pi session and returns compact session metadata plus the child's final answer.
 
@@ -71,9 +75,12 @@ Arguments:
 
 - `task` is required. It is the prompt for the child session.
 - `agent` is optional. Omit it for the generic default mode. Pass a
-  filename stem such as `"reviewer"` to use a markdown agent named
-  `reviewer.md`. A literal `agent: "subagent"` means the markdown file
+  filename stem such as `"vision"` to use a markdown agent named
+  `vision.md`. A literal `agent: "subagent"` means the markdown file
   `subagent.md`; omission is the only way to request the default mode.
+- `model` is optional. Pass a model ID such as `"glm-5v-turbo"` or a
+  canonical `provider/model-id` reference. It overrides the named
+  agent's frontmatter model for this call.
 - `context` is optional and defaults to `"fresh"`. Use `"fresh"` for a
   new child session. Use `"fork"` only when the child must inherit the
   current conversation branch.
@@ -83,6 +90,13 @@ Arguments:
   paths and bash run there, and project-agent discovery, context
   files such as `AGENTS.md` / `CLAUDE.md`, skills, and Pi resources
   follow that cwd. Relative `cwd` values resolve from the caller cwd.
+
+Model references must match Pi's current model catalog and have
+configured authentication. For a bare model ID, `pi-submarine` first
+prefers a matching model from the parent's provider, then the only
+authenticated match; otherwise it asks for a canonical reference. If
+neither the call nor the agent chooses a model, fresh runs inherit the
+parent model and fork runs restore the model from the copied branch.
 
 Fresh runs create a new child session below the current root session's
 `.subagents/` directory; nested subagents share that directory. The
@@ -97,7 +111,7 @@ been found from the caller cwd, `subagent` fails with a hint to omit
 A successful result looks like this:
 
 ```md
-## Subagent reviewer result
+## Subagent vision result
 Subagent session ID: 019...
 
 <child assistant answer>
@@ -162,37 +176,46 @@ otherwise Pi's normal agent directory). Project agents live in the
 nearest ancestor `.pi/agents/*.md` from the effective cwd. Project
 agents override user agents with the same filename stem.
 
-For project agents, normally pass the agent name and omit `cwd`:
+For project agents, normally pass the agent name and omit `cwd`. For
+example, create `.pi/agents/vision.md`:
+
+```md
+---
+description: Reads screenshots, diagrams, and other images.
+model: glm-5v-turbo
+agentsMd: auto
+skills: none
+---
+
+Read every image path named in the task. If no path is given, find the
+relevant image files in the cwd first. Return visible text and a concise
+description, separating direct observations from inferences.
+```
+
+The frontmatter model is the default:
 
 ```ts
-subagent({ agent: "reviewer", task: "Review the changes in src/runner.ts." })
+subagent({ agent: "vision", task: "Read screenshots/login.png and return its contents." })
+```
+
+A call-level model selects or overrides it for one invocation:
+
+```ts
+subagent({ agent: "vision", task: "Read any screenshots or images and return their contents", model: "glm-5v-turbo" })
 ```
 
 If the task needs files outside the project, put those paths in `task`
 unless you intentionally want the external directory to define the
 child's project context.
 
-Agent files use a small frontmatter block, not YAML:
-
-```md
----
-description: Reviews branch for correctness, tests, and unnecessary complexity.
-agentsMd: auto
-skills: none
----
-
-Perform an adversarial review of the changes in this branch. Look for
-opportunities to reduce layers, remove complexity, and increase
-reliability. Ensure repo-wide policies are maintained, changes are
-verified, and maintain the original intent.
-```
-
-`description` is required. `agentsMd` is optional and may be `none` or
-`auto`; it defaults to `none`. `skills` is optional and may be `auto`,
-`none`, or a comma-separated list of skill names; it defaults to
-`auto`. Unknown keys, blank frontmatter lines, comments, quoted
-values, arrays, block scalars, duplicate keys, missing delimiters, and
-empty bodies are rejected.
+Agent files use the small frontmatter block shown above, not YAML.
+`description` is required. `model` is optional and uses the same model
+reference rules as the call-level argument. `agentsMd` is optional and
+may be `none` or `auto`; it defaults to `none`. `skills` is optional
+and may be `auto`, `none`, or a comma-separated list of skill names;
+it defaults to `auto`. Unknown keys, blank frontmatter lines,
+comments, quoted values, arrays, block scalars, duplicate keys,
+missing delimiters, and empty bodies are rejected.
 
 Discovery is non-recursive and ignores hidden files, nested
 directories, uppercase `.MD`, and `*.chain.md` files.
@@ -206,7 +229,10 @@ keep normal skills. For named fresh runs, `agentsMd` controls
 context-file loading and `skills` controls skill loading; the agent
 body stays in the user prompt envelope rather than the child system
 prompt. Fork runs ignore those frontmatter resource controls but use
-the same user prompt envelope for omitted and named agents.
+the same user prompt envelope for omitted and named agents. A
+frontmatter model applies to both fresh and forked initial runs.
+Resuming restores the model recorded in the child session rather than
+reapplying the current agent-file default.
 
 ## Artifacts and progress
 
@@ -233,7 +259,7 @@ like this:
 
 ```text
 Log: ~/.pi/agent/sessions/.../parent.jsonl.subagents.md
-- subagent (6% ctx, 1 turn) -> reviewer (? ctx, 2 turns): using read
+- subagent (6% ctx, 1 turn) -> vision (? ctx, 2 turns): using read
 ```
 
 The same update includes structured `details.run` data:
@@ -282,6 +308,10 @@ is required for correctness.
   as a cautious “may be resumable” handle. Preflight and lookup
   failures before a trusted child session exists do not invent a
   continuation handle.
+- Requested and recorded models are checked before the child is
+  prompted. If a model is unavailable or unauthenticated, or Pi
+  reports that it would fall back, the run fails instead of silently
+  using a substitute.
 - `pi-submarine`'s wrapper text does not add session-file paths,
   activity-log paths, stack traces, child transcripts, or the Markdown
   activity log to model-visible success, interruption, or recovery

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -5,7 +5,7 @@ import type { AgentResourceMode, AgentSelection, MarkdownAgent, MarkdownAgentSou
 import { namedAgentSelection, omittedAgentSelection } from "./render.js";
 
 const FRONTMATTER_DELIMITER = "---";
-const VALID_FRONTMATTER_KEYS = new Set(["description", "agentsMd", "skills"]);
+const VALID_FRONTMATTER_KEYS = new Set(["description", "model", "agentsMd", "skills"]);
 
 export interface AgentDiscoveryResult {
   agents: MarkdownAgent[];
@@ -108,6 +108,9 @@ export function parseMarkdownAgent(content: string, options: ParseMarkdownAgentO
   const description = fields.get("description")?.trim() ?? "";
   if (description === "") fail("description is required and must be non-empty");
 
+  const rawModel = fields.get("model");
+  const model = rawModel === undefined ? undefined : rawModel || fail("model must be non-empty");
+
   const rawAgentsMd = fields.get("agentsMd") ?? "none";
   const agentsMd: AgentResourceMode = rawAgentsMd === "none" ? "none" : rawAgentsMd === "auto" ? "auto" : fail("agentsMd must be 'none' or 'auto'");
 
@@ -121,6 +124,7 @@ export function parseMarkdownAgent(content: string, options: ParseMarkdownAgentO
     source: options.source,
     filePath: options.filePath,
     body,
+    ...(model === undefined ? {} : { model }),
     agentsMd,
     skills,
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export const subagentParameters = Type.Object(
   {
     agent: Type.Optional(Type.String({ description: TOOL_PROMPTS.subagent.parameterDescriptions.agent })),
     task: Type.String({ minLength: 1, description: TOOL_PROMPTS.subagent.parameterDescriptions.task }),
+    model: Type.Optional(Type.String({ minLength: 1, description: TOOL_PROMPTS.subagent.parameterDescriptions.model })),
     context: Type.Optional(
       StringEnum(["fresh", "fork"] as const, {
         default: "fresh",

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,0 +1,90 @@
+import type { Api, Model } from "@earendil-works/pi-ai";
+import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
+
+type SubagentModelRegistry = Pick<ModelRegistry, "getAll" | "hasConfiguredAuth">;
+
+export function resolveRecordedSubagentModel(
+  provider: string,
+  modelId: string,
+  modelRegistry: SubagentModelRegistry,
+): Model<Api> {
+  const model = modelRegistry.getAll().find(
+    (candidate) => candidate.provider === provider && candidate.id === modelId,
+  );
+  if (!model) {
+    throw new Error(`Recorded subagent model '${provider}/${modelId}' not found in Pi's model catalog.`);
+  }
+  return requireAuthenticatedModel(model, modelRegistry);
+}
+
+export function resolveSubagentModel(
+  rawReference: string | undefined,
+  modelRegistry: SubagentModelRegistry,
+  preferredProvider?: string,
+): Model<Api> | undefined {
+  if (rawReference === undefined) return undefined;
+
+  const reference = rawReference.trim();
+  if (!reference) {
+    throw new Error("Invalid subagent model: provide a non-empty model ID or provider/model ID.");
+  }
+
+  const models = modelRegistry.getAll();
+  const normalizedReference = reference.toLowerCase();
+  const canonicalMatches = models.filter(
+    (model) => `${model.provider}/${model.id}`.toLowerCase() === normalizedReference,
+  );
+  if (canonicalMatches.length > 0) {
+    return requireSingleAuthenticatedModel(reference, canonicalMatches, modelRegistry);
+  }
+
+  const idMatches = models.filter((model) => model.id.toLowerCase() === normalizedReference);
+  if (idMatches.length === 0) {
+    throw new Error(`Subagent model '${reference}' not found. Use a model ID or provider/model ID from Pi's model catalog.`);
+  }
+
+  const authenticatedMatches = idMatches.filter((model) => modelRegistry.hasConfiguredAuth(model));
+  if (preferredProvider) {
+    const preferredMatches = authenticatedMatches.filter(
+      (model) => model.provider.toLowerCase() === preferredProvider.toLowerCase(),
+    );
+    if (preferredMatches.length === 1) return preferredMatches[0];
+  }
+
+  if (authenticatedMatches.length === 1) return authenticatedMatches[0];
+  if (authenticatedMatches.length === 0) {
+    if (idMatches.length === 1) return requireAuthenticatedModel(idMatches[0]!, modelRegistry);
+    throw new Error(
+      `No authentication configured for any subagent model matching '${reference}'. Candidates: ${formatCandidates(idMatches)}.`,
+    );
+  }
+
+  throw new Error(
+    `Subagent model '${reference}' is ambiguous. Use a provider/model ID: ${formatCandidates(authenticatedMatches)}.`,
+  );
+}
+
+function requireSingleAuthenticatedModel(
+  reference: string,
+  matches: Model<Api>[],
+  modelRegistry: SubagentModelRegistry,
+): Model<Api> {
+  if (matches.length !== 1) {
+    throw new Error(`Subagent model '${reference}' is ambiguous. Candidates: ${formatCandidates(matches)}.`);
+  }
+  return requireAuthenticatedModel(matches[0]!, modelRegistry);
+}
+
+function requireAuthenticatedModel(model: Model<Api>, modelRegistry: SubagentModelRegistry): Model<Api> {
+  if (!modelRegistry.hasConfiguredAuth(model)) {
+    throw new Error(`No authentication configured for subagent model '${model.provider}/${model.id}'.`);
+  }
+  return model;
+}
+
+function formatCandidates(models: Model<Api>[]): string {
+  return models
+    .map((model) => `${model.provider}/${model.id}`)
+    .sort((left, right) => left.localeCompare(right))
+    .join(", ");
+}

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -73,26 +73,22 @@ interface BaseRunPlan {
   settingsManager: ProjectTrustedSettingsManager;
   resourceLoader: ResourceLoader;
   userPrompt: string;
-  selectedModel: Model<Api> | undefined;
+  model: Model<Api> | undefined;
 }
 
 interface FreshRunPlan extends BaseRunPlan {
   context: "fresh";
-  inheritParentModel: true;
 }
 
 interface ForkRunPlan extends BaseRunPlan {
   context: "fork";
   currentLeafId: string;
   sourceSessionManager: SessionManager;
-  inheritParentModel: false;
 }
 
 type RunPlan = FreshRunPlan | ForkRunPlan;
 
-type ChildSessionPlan = Pick<BaseRunPlan, "effectiveCwd" | "agentDir" | "settingsManager" | "resourceLoader" | "selectedModel"> & {
-  inheritParentModel: boolean;
-};
+type ChildSessionPlan = Pick<BaseRunPlan, "effectiveCwd" | "agentDir" | "settingsManager" | "resourceLoader" | "model">;
 
 interface ResumeRunPlan extends ChildSessionPlan {
   profile: SubagentPromptProfile;
@@ -221,7 +217,7 @@ export async function runSubagent(
   let run: SubagentToolDetails["run"] | undefined;
   let startedRun: StartedRun | undefined;
   let childSession: ChildAgentSession | undefined;
-  let childExtensionsBound = false;
+  let childExtensionsStarted = false;
   let unsubscribe: (() => void) | undefined;
   let detachAbortHandler: (() => void) | undefined;
   let reservedChildSessionFile: string | undefined;
@@ -240,7 +236,7 @@ export async function runSubagent(
     const created = await createChildSession(plan, startedRun.childSessionManager, deps, ctx);
     childSession = created.session;
     throwIfModelFallback(created.modelFallbackMessage);
-    childExtensionsBound = true;
+    childExtensionsStarted = true;
     await bindChildExtensions(childSession);
     const activeChildSession = childSession;
     const abortState = attachAbortHandler(signal, activeChildSession);
@@ -271,7 +267,7 @@ export async function runSubagent(
     const interrupted = isSubagentInterruptedError(error);
     await activityLogWriter?.drain();
     if (run && childSession) refreshContextUsage(run, childSession);
-    if (startedRun && plan) preservePlannedModel(plan, startedRun.childSessionManager, ctx);
+    if (startedRun && plan) preservePlannedModel(plan, startedRun.childSessionManager);
     if (startedRun) await materializeChildSessionFile(startedRun.childSessionManager);
     if (startedRun && plan) {
       if (interrupted) await abortRun(plan.manifestPath, startedRun, deps, onUpdate, activityLogWriter);
@@ -283,10 +279,10 @@ export async function runSubagent(
     if (run) throw new Error(renderSubagentRecoverableError(selection, run.sessionId, message));
     throw new Error(`${errorHeading(selection)}\n\n${message}`);
   } finally {
-    releaseActiveChildSession(reservedChildSessionFile);
     runCleanup("remove subagent abort listener", detachAbortHandler);
     runCleanup("unsubscribe subagent activity listener", unsubscribe);
-    await disposeChildSession(childSession, childExtensionsBound, "subagent");
+    await closeChildSession(childSession, childExtensionsStarted, "subagent");
+    releaseActiveChildSession(reservedChildSessionFile);
   }
 }
 
@@ -301,7 +297,7 @@ export async function runSubagentResume(
   let plan: ResumeRunPlan | undefined;
   let run: SubagentToolDetails["run"] | undefined;
   let childSession: ChildAgentSession | undefined;
-  let childExtensionsBound = false;
+  let childExtensionsStarted = false;
   let unsubscribe: (() => void) | undefined;
   let detachAbortHandler: (() => void) | undefined;
   let reservedChildSessionFile: string | undefined;
@@ -342,7 +338,7 @@ export async function runSubagentResume(
     const created = await createChildSession(plan, plan.childSessionManager, deps, ctx);
     childSession = created.session;
     throwIfModelFallback(created.modelFallbackMessage);
-    childExtensionsBound = true;
+    childExtensionsStarted = true;
     await bindChildExtensions(childSession);
     const activeChildSession = childSession;
     const abortState = attachAbortHandler(signal, activeChildSession);
@@ -382,10 +378,10 @@ export async function runSubagentResume(
     throw new Error(`${heading}\n\n${message}`);
   } finally {
     if (run) forgetRuntimeEpisode(run.episodeId);
-    releaseActiveChildSession(reservedChildSessionFile);
     runCleanup("remove subagent resume abort listener", detachAbortHandler);
     runCleanup("unsubscribe subagent resume activity listener", unsubscribe);
-    await disposeChildSession(childSession, childExtensionsBound, "resumed subagent");
+    await closeChildSession(childSession, childExtensionsStarted, "resumed subagent");
+    releaseActiveChildSession(reservedChildSessionFile);
   }
 }
 
@@ -446,7 +442,7 @@ async function prepareResumeRun(
   const userAgentsDir = path.join(agentDir, "agents");
   const profile = await resolveResumeProfile(startedRecord, effectiveCwd, userAgentsDir);
   const recordedModel = childSessionManager.buildSessionContext().model;
-  const selectedModel = recordedModel
+  const model = recordedModel
     ? resolveRecordedSubagentModel(recordedModel.provider, recordedModel.modelId, ctx.modelRegistry)
     : undefined;
   const loaderContext = extensionFactories === undefined
@@ -473,8 +469,7 @@ async function prepareResumeRun(
     settingsManager,
     resourceLoader,
     userPrompt: params.message,
-    selectedModel,
-    inheritParentModel: false,
+    model,
   };
 }
 
@@ -498,7 +493,8 @@ async function prepareFreshRun(
   const settingsManager = createProjectTrustedSettingsManager(effectiveCwd, agentDir);
   const userAgentsDir = path.join(agentDir, "agents");
   const profile = await resolveAgentProfile(params, effectiveCwd, profileResolutionOptions(userAgentsDir, params, ctx));
-  const selectedModel = resolveSubagentModel(params.model ?? profile.model, ctx.modelRegistry, ctx.model?.provider);
+  const parentModel = ctx.model;
+  const model = resolveSubagentModel(params.model ?? profile.model, ctx.modelRegistry, parentModel?.provider) ?? parentModel;
   const { root, manifestPath, parentDepth, parentPath } = await resolveArtifactRoot(parentSessionFile);
   const loaderContext = extensionFactories === undefined
     ? { cwd: effectiveCwd, agentDir, settingsManager }
@@ -518,8 +514,7 @@ async function prepareFreshRun(
     settingsManager,
     resourceLoader,
     userPrompt: buildInitialSubagentPrompt(profile, "fresh", params.task, parentDepth),
-    selectedModel,
-    inheritParentModel: true,
+    model,
   };
 }
 
@@ -549,7 +544,8 @@ async function prepareForkRun(
   const settingsManager = createProjectTrustedSettingsManager(effectiveCwd, agentDir);
   const userAgentsDir = path.join(agentDir, "agents");
   const profile = await resolveAgentProfile(params, effectiveCwd, { userAgentsDir });
-  const selectedModel = resolveSubagentModel(params.model ?? profile.model, ctx.modelRegistry, ctx.model?.provider);
+  const parentModel = ctx.model;
+  const model = resolveSubagentModel(params.model ?? profile.model, ctx.modelRegistry, parentModel?.provider);
   const loaderContext = extensionFactories === undefined
     ? { cwd: effectiveCwd, agentDir, settingsManager }
     : { cwd: effectiveCwd, agentDir, settingsManager, extensionFactories };
@@ -568,10 +564,9 @@ async function prepareForkRun(
     settingsManager,
     resourceLoader,
     userPrompt: buildInitialSubagentPrompt(profile, "fork", params.task, parentDepth),
-    selectedModel,
+    model,
     currentLeafId,
     sourceSessionManager,
-    inheritParentModel: false,
   };
 }
 
@@ -749,8 +744,8 @@ async function startRunArtifacts(
   const activityLog = plan.root.activityLogPath;
   const activityPath = [...plan.parentPath, plan.profile.agentName];
   const childSessionManager = createChildSessionManager(plan, deps);
-  if (plan.context === "fork" && plan.selectedModel) {
-    childSessionManager.appendModelChange(plan.selectedModel.provider, plan.selectedModel.id);
+  if (plan.context === "fork" && plan.model) {
+    childSessionManager.appendModelChange(plan.model.provider, plan.model.id);
   }
   const childSessionFile = childSessionManager.getSessionFile();
   if (!childSessionFile) throw new Error("Could not create a persisted child subagent session.");
@@ -820,30 +815,24 @@ async function createChildSession(
   deps: RunnerDependencies,
   ctx: ExtensionContext,
 ): Promise<ChildSessionResult> {
-  const model = plannedChildModel(plan, ctx);
   return deps.createAgentSession({
     cwd: plan.effectiveCwd,
     agentDir: plan.agentDir,
     modelRegistry: ctx.modelRegistry,
-    ...(model === undefined ? {} : { model }),
+    ...(plan.model === undefined ? {} : { model: plan.model }),
     settingsManager: plan.settingsManager,
     resourceLoader: plan.resourceLoader,
     sessionManager: childSessionManager,
   });
 }
 
-function plannedChildModel(plan: ChildSessionPlan, ctx: ExtensionContext): Model<Api> | undefined {
-  return plan.selectedModel ?? (plan.inheritParentModel ? ctx.model : undefined);
-}
-
-function preservePlannedModel(plan: ChildSessionPlan, childSessionManager: SessionManager, ctx: ExtensionContext): void {
-  const model = plannedChildModel(plan, ctx);
-  if (!model) return;
+function preservePlannedModel(plan: ChildSessionPlan, childSessionManager: SessionManager): void {
+  if (!plan.model) return;
 
   try {
     const recordedModel = childSessionManager.buildSessionContext().model;
     if (recordedModel) return;
-    childSessionManager.appendModelChange(model.provider, model.id);
+    childSessionManager.appendModelChange(plan.model.provider, plan.model.id);
   } catch (error: unknown) {
     console.error("subagent child model persistence failed", error);
   }
@@ -857,14 +846,14 @@ async function bindChildExtensions(childSession: ChildAgentSession): Promise<voi
   await childSession.bindExtensions({ onError: (error: unknown) => console.error("subagent extension error", error) });
 }
 
-async function disposeChildSession(
+async function closeChildSession(
   childSession: ChildAgentSession | undefined,
-  extensionsBound: boolean,
+  extensionsStarted: boolean,
   label: string,
 ): Promise<void> {
   if (!childSession) return;
 
-  if (extensionsBound) {
+  if (extensionsStarted) {
     try {
       if (childSession.hasExtensionHandlers("session_shutdown")) {
         await childSession.extensionRunner.emit({ type: "session_shutdown", reason: "quit" });

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -28,7 +28,7 @@ import { OMITTED_AGENT_LABEL, type AgentSelection, type MarkdownAgent, type Suba
 
 type DefaultResourceLoaderOptions = ConstructorParameters<typeof DefaultResourceLoader>[0];
 type ProjectTrustedSettingsManager = ReturnType<typeof SettingsManager.create>;
-type ChildAgentSession = Pick<AgentSession, "prompt" | "getLastAssistantText" | "getContextUsage" | "subscribe" | "bindExtensions" | "abort" | "dispose" | "messages">;
+type ChildAgentSession = Pick<AgentSession, "prompt" | "getLastAssistantText" | "getContextUsage" | "subscribe" | "bindExtensions" | "hasExtensionHandlers" | "extensionRunner" | "abort" | "dispose" | "messages">;
 type ChildSessionResult = Pick<CreateAgentSessionResult, "session" | "modelFallbackMessage">;
 type ManifestRecords = Awaited<ReturnType<typeof readManifestRecords>>;
 
@@ -221,6 +221,7 @@ export async function runSubagent(
   let run: SubagentToolDetails["run"] | undefined;
   let startedRun: StartedRun | undefined;
   let childSession: ChildAgentSession | undefined;
+  let childExtensionsBound = false;
   let unsubscribe: (() => void) | undefined;
   let detachAbortHandler: (() => void) | undefined;
   let reservedChildSessionFile: string | undefined;
@@ -239,6 +240,7 @@ export async function runSubagent(
     const created = await createChildSession(plan, startedRun.childSessionManager, deps, ctx);
     childSession = created.session;
     throwIfModelFallback(created.modelFallbackMessage);
+    childExtensionsBound = true;
     await bindChildExtensions(childSession);
     const activeChildSession = childSession;
     const abortState = attachAbortHandler(signal, activeChildSession);
@@ -284,7 +286,7 @@ export async function runSubagent(
     releaseActiveChildSession(reservedChildSessionFile);
     runCleanup("remove subagent abort listener", detachAbortHandler);
     runCleanup("unsubscribe subagent activity listener", unsubscribe);
-    runCleanup("dispose subagent child session", () => childSession?.dispose());
+    await disposeChildSession(childSession, childExtensionsBound, "subagent");
   }
 }
 
@@ -299,6 +301,7 @@ export async function runSubagentResume(
   let plan: ResumeRunPlan | undefined;
   let run: SubagentToolDetails["run"] | undefined;
   let childSession: ChildAgentSession | undefined;
+  let childExtensionsBound = false;
   let unsubscribe: (() => void) | undefined;
   let detachAbortHandler: (() => void) | undefined;
   let reservedChildSessionFile: string | undefined;
@@ -339,6 +342,7 @@ export async function runSubagentResume(
     const created = await createChildSession(plan, plan.childSessionManager, deps, ctx);
     childSession = created.session;
     throwIfModelFallback(created.modelFallbackMessage);
+    childExtensionsBound = true;
     await bindChildExtensions(childSession);
     const activeChildSession = childSession;
     const abortState = attachAbortHandler(signal, activeChildSession);
@@ -381,7 +385,7 @@ export async function runSubagentResume(
     releaseActiveChildSession(reservedChildSessionFile);
     runCleanup("remove subagent resume abort listener", detachAbortHandler);
     runCleanup("unsubscribe subagent resume activity listener", unsubscribe);
-    runCleanup("dispose resumed subagent child session", () => childSession?.dispose());
+    await disposeChildSession(childSession, childExtensionsBound, "resumed subagent");
   }
 }
 
@@ -851,6 +855,26 @@ function throwIfModelFallback(modelFallbackMessage: string | undefined): void {
 
 async function bindChildExtensions(childSession: ChildAgentSession): Promise<void> {
   await childSession.bindExtensions({ onError: (error: unknown) => console.error("subagent extension error", error) });
+}
+
+async function disposeChildSession(
+  childSession: ChildAgentSession | undefined,
+  extensionsBound: boolean,
+  label: string,
+): Promise<void> {
+  if (!childSession) return;
+
+  if (extensionsBound) {
+    try {
+      if (childSession.hasExtensionHandlers("session_shutdown")) {
+        await childSession.extensionRunner.emit({ type: "session_shutdown", reason: "quit" });
+      }
+    } catch (error: unknown) {
+      console.error(`Could not shut down ${label} child extensions`, error);
+    }
+  }
+
+  runCleanup(`dispose ${label} child session`, () => childSession.dispose());
 }
 
 function refreshContextUsage(run: SubagentToolDetails["run"], childSession: ChildAgentSession): void {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,5 +1,6 @@
 import { mkdir, open, writeFile } from "node:fs/promises";
 import path from "node:path";
+import type { Api, Model } from "@earendil-works/pi-ai";
 import {
   DefaultResourceLoader,
   createAgentSession,
@@ -19,6 +20,7 @@ import { MissingMarkdownAgentError, resolveMarkdownAgent } from "./agents.js";
 import { cloneRunView, createActivityState, createInitialRunView, reduceActivityEvent } from "./activity.js";
 import { QueuedActivityLogWriter, appendActivityLogFinished, appendActivityLogStarted, ensureActivityLogHeader, type DegradedActivityLogOptions } from "./activity-log.js";
 import { appendManifestRecord, findLatestEpisodeStartedRecordBySessionFile, readManifestRecords, requireUniqueStartedRecordBySessionId, type DegradedAppendOptions, type EpisodeStartedManifestRecord, type StartedManifestRecord } from "./manifest.js";
+import { resolveRecordedSubagentModel, resolveSubagentModel } from "./models.js";
 import { errorHeading, namedAgentSelection, omittedAgentSelection, renderSubagentInterrupted, renderSubagentProgress, renderSubagentRecoverableError, renderSubagentResult } from "./render.js";
 import { assertDirectoryExists, manifestPathForSubagentsRoot, resolveFreshCwd, resolveSubagentsRoot, type SubagentsRoot } from "./sessions.js";
 import { buildSubagentPromptEnvelope } from "./tool-prompts.js";
@@ -27,7 +29,7 @@ import { OMITTED_AGENT_LABEL, type AgentSelection, type MarkdownAgent, type Suba
 type DefaultResourceLoaderOptions = ConstructorParameters<typeof DefaultResourceLoader>[0];
 type ProjectTrustedSettingsManager = ReturnType<typeof SettingsManager.create>;
 type ChildAgentSession = Pick<AgentSession, "prompt" | "getLastAssistantText" | "getContextUsage" | "subscribe" | "bindExtensions" | "abort" | "dispose" | "messages">;
-type ChildSessionResult = Pick<CreateAgentSessionResult, "session">;
+type ChildSessionResult = Pick<CreateAgentSessionResult, "session" | "modelFallbackMessage">;
 type ManifestRecords = Awaited<ReturnType<typeof readManifestRecords>>;
 
 export interface SubagentPromptProfile {
@@ -35,6 +37,7 @@ export interface SubagentPromptProfile {
   agentName: string;
   agentFile?: string;
   agentBody?: string;
+  model?: string;
   agentsMd: "none" | "auto";
   skills: MarkdownAgent["skills"];
 }
@@ -70,6 +73,7 @@ interface BaseRunPlan {
   settingsManager: ProjectTrustedSettingsManager;
   resourceLoader: ResourceLoader;
   userPrompt: string;
+  selectedModel: Model<Api> | undefined;
 }
 
 interface FreshRunPlan extends BaseRunPlan {
@@ -86,7 +90,7 @@ interface ForkRunPlan extends BaseRunPlan {
 
 type RunPlan = FreshRunPlan | ForkRunPlan;
 
-type ChildSessionPlan = Pick<BaseRunPlan, "effectiveCwd" | "agentDir" | "settingsManager" | "resourceLoader"> & {
+type ChildSessionPlan = Pick<BaseRunPlan, "effectiveCwd" | "agentDir" | "settingsManager" | "resourceLoader" | "selectedModel"> & {
   inheritParentModel: boolean;
 };
 
@@ -145,6 +149,7 @@ export function namedSubagentProfile(agent: MarkdownAgent): SubagentPromptProfil
     agentName: agent.name,
     agentFile: agent.filePath,
     agentBody: agent.body,
+    ...(agent.model === undefined ? {} : { model: agent.model }),
     agentsMd: agent.agentsMd,
     skills: agent.skills,
   };
@@ -231,7 +236,9 @@ export async function runSubagent(
     throwIfInterrupted(signal);
     emitUpdate(onUpdate, run);
 
-    childSession = await createChildSession(plan, startedRun.childSessionManager, deps, ctx);
+    const created = await createChildSession(plan, startedRun.childSessionManager, deps, ctx);
+    childSession = created.session;
+    throwIfModelFallback(created.modelFallbackMessage);
     await bindChildExtensions(childSession);
     const activeChildSession = childSession;
     const abortState = attachAbortHandler(signal, activeChildSession);
@@ -262,6 +269,7 @@ export async function runSubagent(
     const interrupted = isSubagentInterruptedError(error);
     await activityLogWriter?.drain();
     if (run && childSession) refreshContextUsage(run, childSession);
+    if (startedRun && plan) preservePlannedModel(plan, startedRun.childSessionManager, ctx);
     if (startedRun) await materializeChildSessionFile(startedRun.childSessionManager);
     if (startedRun && plan) {
       if (interrupted) await abortRun(plan.manifestPath, startedRun, deps, onUpdate, activityLogWriter);
@@ -328,7 +336,9 @@ export async function runSubagentResume(
     emitUpdate(onUpdate, run);
     throwIfInterrupted(signal);
 
-    childSession = await createChildSession(plan, plan.childSessionManager, deps, ctx);
+    const created = await createChildSession(plan, plan.childSessionManager, deps, ctx);
+    childSession = created.session;
+    throwIfModelFallback(created.modelFallbackMessage);
     await bindChildExtensions(childSession);
     const activeChildSession = childSession;
     const abortState = attachAbortHandler(signal, activeChildSession);
@@ -431,6 +441,10 @@ async function prepareResumeRun(
   const settingsManager = createProjectTrustedSettingsManager(effectiveCwd, agentDir);
   const userAgentsDir = path.join(agentDir, "agents");
   const profile = await resolveResumeProfile(startedRecord, effectiveCwd, userAgentsDir);
+  const recordedModel = childSessionManager.buildSessionContext().model;
+  const selectedModel = recordedModel
+    ? resolveRecordedSubagentModel(recordedModel.provider, recordedModel.modelId, ctx.modelRegistry)
+    : undefined;
   const loaderContext = extensionFactories === undefined
     ? { cwd: effectiveCwd, agentDir, settingsManager }
     : { cwd: effectiveCwd, agentDir, settingsManager, extensionFactories };
@@ -455,6 +469,7 @@ async function prepareResumeRun(
     settingsManager,
     resourceLoader,
     userPrompt: params.message,
+    selectedModel,
     inheritParentModel: false,
   };
 }
@@ -479,6 +494,7 @@ async function prepareFreshRun(
   const settingsManager = createProjectTrustedSettingsManager(effectiveCwd, agentDir);
   const userAgentsDir = path.join(agentDir, "agents");
   const profile = await resolveAgentProfile(params, effectiveCwd, profileResolutionOptions(userAgentsDir, params, ctx));
+  const selectedModel = resolveSubagentModel(params.model ?? profile.model, ctx.modelRegistry, ctx.model?.provider);
   const { root, manifestPath, parentDepth, parentPath } = await resolveArtifactRoot(parentSessionFile);
   const loaderContext = extensionFactories === undefined
     ? { cwd: effectiveCwd, agentDir, settingsManager }
@@ -498,6 +514,7 @@ async function prepareFreshRun(
     settingsManager,
     resourceLoader,
     userPrompt: buildInitialSubagentPrompt(profile, "fresh", params.task, parentDepth),
+    selectedModel,
     inheritParentModel: true,
   };
 }
@@ -528,6 +545,7 @@ async function prepareForkRun(
   const settingsManager = createProjectTrustedSettingsManager(effectiveCwd, agentDir);
   const userAgentsDir = path.join(agentDir, "agents");
   const profile = await resolveAgentProfile(params, effectiveCwd, { userAgentsDir });
+  const selectedModel = resolveSubagentModel(params.model ?? profile.model, ctx.modelRegistry, ctx.model?.provider);
   const loaderContext = extensionFactories === undefined
     ? { cwd: effectiveCwd, agentDir, settingsManager }
     : { cwd: effectiveCwd, agentDir, settingsManager, extensionFactories };
@@ -546,6 +564,7 @@ async function prepareForkRun(
     settingsManager,
     resourceLoader,
     userPrompt: buildInitialSubagentPrompt(profile, "fork", params.task, parentDepth),
+    selectedModel,
     currentLeafId,
     sourceSessionManager,
     inheritParentModel: false,
@@ -726,6 +745,9 @@ async function startRunArtifacts(
   const activityLog = plan.root.activityLogPath;
   const activityPath = [...plan.parentPath, plan.profile.agentName];
   const childSessionManager = createChildSessionManager(plan, deps);
+  if (plan.context === "fork" && plan.selectedModel) {
+    childSessionManager.appendModelChange(plan.selectedModel.provider, plan.selectedModel.id);
+  }
   const childSessionFile = childSessionManager.getSessionFile();
   if (!childSessionFile) throw new Error("Could not create a persisted child subagent session.");
   const sessionId = childSessionManager.getSessionId();
@@ -793,17 +815,38 @@ async function createChildSession(
   childSessionManager: SessionManager,
   deps: RunnerDependencies,
   ctx: ExtensionContext,
-): Promise<ChildAgentSession> {
-  const created = await deps.createAgentSession({
+): Promise<ChildSessionResult> {
+  const model = plannedChildModel(plan, ctx);
+  return deps.createAgentSession({
     cwd: plan.effectiveCwd,
     agentDir: plan.agentDir,
     modelRegistry: ctx.modelRegistry,
-    ...(plan.inheritParentModel && ctx.model !== undefined ? { model: ctx.model } : {}),
+    ...(model === undefined ? {} : { model }),
     settingsManager: plan.settingsManager,
     resourceLoader: plan.resourceLoader,
     sessionManager: childSessionManager,
   });
-  return created.session;
+}
+
+function plannedChildModel(plan: ChildSessionPlan, ctx: ExtensionContext): Model<Api> | undefined {
+  return plan.selectedModel ?? (plan.inheritParentModel ? ctx.model : undefined);
+}
+
+function preservePlannedModel(plan: ChildSessionPlan, childSessionManager: SessionManager, ctx: ExtensionContext): void {
+  const model = plannedChildModel(plan, ctx);
+  if (!model) return;
+
+  try {
+    const recordedModel = childSessionManager.buildSessionContext().model;
+    if (recordedModel) return;
+    childSessionManager.appendModelChange(model.provider, model.id);
+  } catch (error: unknown) {
+    console.error("subagent child model persistence failed", error);
+  }
+}
+
+function throwIfModelFallback(modelFallbackMessage: string | undefined): void {
+  if (modelFallbackMessage) throw new Error(modelFallbackMessage);
 }
 
 async function bindChildExtensions(childSession: ChildAgentSession): Promise<void> {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -892,18 +892,33 @@ function copyContextUsage(contextUsage: SubagentContextUsage): SubagentContextUs
   };
 }
 
-function attachAbortHandler(signal: AbortSignal | undefined, childSession: ChildAgentSession): { wasAborted: () => boolean; aborted: Promise<void>; detach: () => void } {
+interface ChildAbortState {
+  wasAborted: () => boolean;
+  aborted: Promise<void>;
+  settled: Promise<void>;
+  detach: () => void;
+}
+
+function attachAbortHandler(signal: AbortSignal | undefined, childSession: ChildAgentSession): ChildAbortState {
   let abortRequested = false;
   let resolveAbort!: () => void;
+  let resolveSettled!: () => void;
   const aborted = new Promise<void>((resolve) => {
     resolveAbort = resolve;
   });
+  const settled = new Promise<void>((resolve) => {
+    resolveSettled = resolve;
+  });
   const abortChild = () => {
+    if (abortRequested) return;
     abortRequested = true;
     resolveAbort();
-    void childSession.abort().catch((error: unknown) => {
-      console.error("subagent child abort failed", error);
-    });
+    void Promise.resolve()
+      .then(() => childSession.abort())
+      .catch((error: unknown) => {
+        console.error("subagent child abort failed", error);
+      })
+      .finally(resolveSettled);
   };
 
   signal?.addEventListener("abort", abortChild, { once: true });
@@ -912,14 +927,18 @@ function attachAbortHandler(signal: AbortSignal | undefined, childSession: Child
   return {
     wasAborted: () => abortRequested,
     aborted,
+    settled,
     detach: () => {
       if (signal) signal.removeEventListener("abort", abortChild);
     },
   };
 }
 
-async function promptChildAndExtractAnswer(childSession: ChildAgentSession, childSessionManager: SessionManager, task: string, abortState: { wasAborted: () => boolean; aborted: Promise<void> }): Promise<string> {
-  if (abortState.wasAborted()) throw new SubagentInterruptedError();
+async function promptChildAndExtractAnswer(childSession: ChildAgentSession, childSessionManager: SessionManager, task: string, abortState: ChildAbortState): Promise<string> {
+  if (abortState.wasAborted()) {
+    await abortState.settled;
+    throw new SubagentInterruptedError();
+  }
   const leafBeforePrompt = childSessionManager.getLeafId();
   const assistantCountBeforePrompt = assistantMessages(childSession.messages ?? []).length;
   const promptPromise = childSession.prompt(task);
@@ -929,10 +948,14 @@ async function promptChildAndExtractAnswer(childSession: ChildAgentSession, chil
   ]);
   if (winner === "abort") {
     void promptPromise.catch((error: unknown) => console.error("subagent child prompt failed after abort", error));
+    await abortState.settled;
     throw new SubagentInterruptedError();
   }
 
-  if (abortState.wasAborted()) throw new SubagentInterruptedError();
+  if (abortState.wasAborted()) {
+    await abortState.settled;
+    throw new SubagentInterruptedError();
+  }
   const newAssistantMessages = assistantMessagesAfterLeaf(childSessionManager, leafBeforePrompt)
     ?? assistantMessages(childSession.messages ?? []).slice(assistantCountBeforePrompt);
   const modelError = finalAssistantFailure(newAssistantMessages);

--- a/src/tool-prompts.ts
+++ b/src/tool-prompts.ts
@@ -6,16 +6,18 @@ export const TOOL_PROMPTS = {
     parameterDescriptions: {
       agent: "Markdown agent name, i.e. its filename stem. Omit for default mode; project agents from the effective `cwd` override same-named user-defined agents.",
       task: "Prompt for the child. For `fresh` independent work, make sure to include needed context, paths, constraints, and desired output because the child does not see the parent conversation.",
+      model: "Optional model ID or provider/model ID for this call. Overrides the named agent's frontmatter default; omit it to use that default or normal model inheritance.",
       context: "Defaults to `fresh`. Use `fork` only when the child must inherit a copy of the current conversation; `cwd` is invalid with fork.",
       cwd: "Omit to inherit the caller cwd. Set only to run the child from a different workspace/project, with its tools, agents, context files, and skills.",
     },
     promptGuidelines: [
-      "Common calls: subagent({ task: \"...\" }) for independent work, subagent({ agent: \"reviewer\", task: \"...\" }) to use a specialized named agent, or subagent({ context: \"fork\", task: \"...\" }) when the child should inherit a copy of the current conversation.",
+      "Common calls: subagent({ task: \"...\" }) for independent work, subagent({ agent: \"vision\", task: \"Read any screenshots or images and return their contents\", model: \"glm-5v-turbo\" }) to select a model for a named agent, or subagent({ context: \"fork\", task: \"...\" }) when the child should inherit a copy of the current conversation.",
       "Fresh/default children do not see the parent conversation, so make sure you pass sufficient context in the task!",
       "One call runs one foreground child and waits for the final answer; it is not a background job or workflow engine.",
       "Omit `agent` for default mode; pass an agent name instead to use a specific agent. Role text inside `task` does not select an agent.",
       "Usually omit `cwd`. Use it only when another directory should be the child's workspace/project.",
       "Named `agent`s resolve from the effective cwd; project .pi/agents/*.md overrides same-named user agents.",
+      "A call-level `model` overrides a named agent's frontmatter model; omit it to use the agent default or the existing fresh/fork model behavior.",
     ],
   },
   subagentResume: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export type SubagentContextMode = "fresh" | "fork";
 export interface SubagentParams {
   agent?: string;
   task: string;
+  model?: string;
   context?: SubagentContextMode;
   cwd?: string;
 }
@@ -36,6 +37,7 @@ export interface MarkdownAgent {
   source: MarkdownAgentSource;
   filePath: string;
   body: string;
+  model?: string;
   agentsMd: AgentResourceMode;
   skills: SkillResourceMode;
 }

--- a/test/agents-parser.test.ts
+++ b/test/agents-parser.test.ts
@@ -21,20 +21,26 @@ describe("strict markdown agent parsing", () => {
       source: "project",
       filePath: FILE_PATH,
       body: "You review code.",
+      model: undefined,
       agentsMd: "none",
       skills: "auto",
     });
   });
 
-  it("parses optional agentsMd and skills controls", () => {
-    expect(parse(validAgent("description: Researches\nagentsMd: auto\nskills: none")).agentsMd).toBe("auto");
+  it("parses optional model, agentsMd, and skills controls", () => {
+    const agent = parse(validAgent("description: Researches\nmodel: openrouter/z-ai/glm-5v-turbo:free\nagentsMd: auto\nskills: none"));
+
+    expect(agent.model).toBe("openrouter/z-ai/glm-5v-turbo:free");
+    expect(agent.agentsMd).toBe("auto");
+    expect(agent.skills).toBe("none");
     expect(parse(validAgent("description: Researches\nskills: research, audit")).skills).toEqual({ names: ["research", "audit"] });
   });
 
   it("splits frontmatter values after the first colon only", () => {
-    const agent = parse(validAgent("description: Reviews code: tests: docs"));
+    const agent = parse(validAgent("description: Reviews code: tests: docs\nmodel: provider/model:variant"));
 
     expect(agent.description).toBe("Reviews code: tests: docs");
+    expect(agent.model).toBe("provider/model:variant");
   });
 
   it("accepts CRLF line endings without relaxing delimiter text", () => {
@@ -50,10 +56,11 @@ describe("strict markdown agent parsing", () => {
     ["missing closing delimiter", "---\ndescription: Reviews\nBody", "missing closing delimiter"],
     ["blank frontmatter line", "---\ndescription: Reviews\n\n---\nBody", "blank frontmatter lines are not allowed"],
     ["comment line", "---\ndescription: Reviews\n# no\n---\nBody", "comments are not allowed"],
-    ["unknown key", "---\ndescription: Reviews\nmodel: x\n---\nBody", "unknown key 'model'"],
+    ["unknown key", "---\ndescription: Reviews\ntemperature: 0\n---\nBody", "unknown key 'temperature'"],
     ["duplicate key", "---\ndescription: Reviews\ndescription: Again\n---\nBody", "duplicate key 'description'"],
     ["missing colon", "---\ndescription Reviews\n---\nBody", "must be in key: value form"],
     ["empty description", "---\ndescription:   \n---\nBody", "description is required"],
+    ["empty model", "---\ndescription: Reviews\nmodel:   \n---\nBody", "model must be non-empty"],
     ["quoted double value", "---\ndescription: \"Reviews\"\n---\nBody", "quoted values are invalid"],
     ["quoted single value", "---\ndescription: 'Reviews'\n---\nBody", "quoted values are invalid"],
     ["invalid agentsMd", "---\ndescription: Reviews\nagentsMd: yes\n---\nBody", "agentsMd must be 'none' or 'auto'"],

--- a/test/models.test.ts
+++ b/test/models.test.ts
@@ -1,0 +1,70 @@
+import type { Model } from "@earendil-works/pi-ai";
+import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import { resolveRecordedSubagentModel, resolveSubagentModel } from "../src/models.js";
+
+function model(provider: string, id: string): Model<any> {
+  return { provider, id, name: id } as Model<any>;
+}
+
+function registry(
+  models: Model<any>[],
+  authenticated: Model<any>[] = models,
+): Pick<ModelRegistry, "getAll" | "hasConfiguredAuth"> {
+  const authenticatedModels = new Set(authenticated);
+  return {
+    getAll: () => models,
+    hasConfiguredAuth: (candidate) => authenticatedModels.has(candidate),
+  } as Pick<ModelRegistry, "getAll" | "hasConfiguredAuth">;
+}
+
+describe("subagent model resolution", () => {
+  it("resolves canonical references without splitting slashes or colons in the model ID", () => {
+    const selected = model("openrouter", "z-ai/glm-5v-turbo:free");
+
+    expect(resolveSubagentModel("openrouter/z-ai/glm-5v-turbo:free", registry([selected]))).toBe(selected);
+  });
+
+  it("uses the parent provider to disambiguate a bare model ID", () => {
+    const global = model("zai", "glm-5v-turbo");
+    const china = model("zai-coding-cn", "glm-5v-turbo");
+
+    expect(resolveSubagentModel("glm-5v-turbo", registry([global, china]), "zai-coding-cn")).toBe(china);
+  });
+
+  it("selects the only authenticated match for a bare model ID", () => {
+    const global = model("zai", "glm-5v-turbo");
+    const china = model("zai-coding-cn", "glm-5v-turbo");
+
+    expect(resolveSubagentModel("glm-5v-turbo", registry([global, china], [global]))).toBe(global);
+  });
+
+  it("requires a canonical reference when a bare model ID remains ambiguous", () => {
+    const global = model("zai", "glm-5v-turbo");
+    const china = model("zai-coding-cn", "glm-5v-turbo");
+
+    expect(() => resolveSubagentModel("glm-5v-turbo", registry([global, china]))).toThrow("ambiguous");
+    expect(() => resolveSubagentModel("glm-5v-turbo", registry([global, china]))).toThrow("zai/glm-5v-turbo");
+    expect(() => resolveSubagentModel("glm-5v-turbo", registry([global, china]))).toThrow("zai-coding-cn/glm-5v-turbo");
+  });
+
+  it("does not reinterpret an unavailable recorded model as another provider's raw model ID", () => {
+    const gatewayModel = model("vercel-ai-gateway", "zai/glm-5v-turbo");
+
+    expect(() => resolveRecordedSubagentModel("zai", "glm-5v-turbo", registry([gatewayModel]))).toThrow(
+      "Recorded subagent model 'zai/glm-5v-turbo' not found",
+    );
+  });
+
+  it("rejects blank, unknown, and unauthenticated model references", () => {
+    const selected = model("zai", "glm-5v-turbo");
+    const configuredRegistry = registry([selected]);
+    const unauthenticatedRegistry = registry([selected], []);
+
+    expect(() => resolveSubagentModel("   ", configuredRegistry)).toThrow("non-empty");
+    expect(() => resolveSubagentModel("missing", configuredRegistry)).toThrow("not found");
+    expect(() => resolveSubagentModel("zai/glm-5v-turbo", unauthenticatedRegistry)).toThrow(
+      "No authentication configured",
+    );
+  });
+});

--- a/test/profiles.test.ts
+++ b/test/profiles.test.ts
@@ -10,6 +10,7 @@ const namedAgent: MarkdownAgent = {
   source: "project",
   filePath: "/repo/.pi/agents/reviewer.md",
   body: "Review carefully.",
+  model: "zai/glm-5v-turbo",
   agentsMd: "none",
   skills: { names: ["audit"] },
 };
@@ -33,6 +34,7 @@ describe("subagent prompt-resource profiles", () => {
     const options = buildFreshResourceLoaderOptions(profile, { cwd: "/repo", agentDir: "/agent" });
 
     expect(profile.selection).toEqual({ kind: "named", name: "reviewer", agentFile: namedAgent.filePath });
+    expect(profile.model).toBe("zai/glm-5v-turbo");
     expect(options.noContextFiles).toBe(true);
     expect(options.appendSystemPromptOverride).toBeUndefined();
   });

--- a/test/registration.test.ts
+++ b/test/registration.test.ts
@@ -48,6 +48,7 @@ describe("pi-submarine extension registration", () => {
       properties: {
         agent: { type: "string" },
         task: { type: "string", minLength: 1 },
+        model: { type: "string", minLength: 1 },
         context: { type: "string", enum: ["fresh", "fork"], default: "fresh" },
         cwd: { type: "string" },
       },
@@ -81,7 +82,7 @@ describe("pi-submarine extension registration", () => {
     const guidelines = subagent?.promptGuidelines?.join("\n") ?? "";
     expect(guidelines).toContain("Common calls");
     expect(guidelines).toContain("subagent({ task: \"...\" })");
-    expect(guidelines).toContain("subagent({ agent: \"reviewer\", task: \"...\" })");
+    expect(guidelines).toContain("subagent({ agent: \"vision\", task: \"Read any screenshots or images and return their contents\", model: \"glm-5v-turbo\" })");
     expect(guidelines).toContain("subagent({ context: \"fork\", task: \"...\" })");
     expect(guidelines).toContain("do not see the parent conversation");
     expect(guidelines).toContain("foreground child");
@@ -90,11 +91,13 @@ describe("pi-submarine extension registration", () => {
     expect(guidelines).toContain("Omit `agent` for default mode");
     expect(guidelines).toContain("Role text inside `task` does not select an agent");
     expect(guidelines).toContain("Usually omit `cwd`");
+    expect(guidelines).toContain("call-level `model` overrides");
 
     expect(subagent?.parameters).toMatchObject({
       properties: {
         agent: { description: expect.stringContaining("project agents from the effective `cwd`") },
         task: { description: expect.stringContaining("does not see the parent conversation") },
+        model: { description: expect.stringContaining("frontmatter default") },
         context: { description: expect.stringContaining("Defaults to `fresh`") },
         cwd: { description: expect.stringContaining("Omit to inherit the caller cwd") },
       },

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -27,13 +27,29 @@ class FakeSessionManager {
   getLeafId() { return this.leafId; }
 }
 
-function fakeContext(cwd: string, sessionFile?: string, options: { leafId?: string | null; model?: unknown } = {}): ExtensionContext {
+function fakeContext(
+  cwd: string,
+  sessionFile?: string,
+  options: { leafId?: string | null; model?: unknown; modelRegistry?: unknown } = {},
+): ExtensionContext {
   return {
     cwd,
     sessionManager: new FakeSessionManager(sessionFile, cwd, options.leafId),
-    modelRegistry: {},
+    modelRegistry: options.modelRegistry ?? {},
     model: options.model,
   } as unknown as ExtensionContext;
+}
+
+function fakeModel(provider: string, id: string) {
+  return { provider, id, name: id };
+}
+
+function fakeModelRegistry(models: unknown[], authenticated: unknown[] = models) {
+  const authenticatedModels = new Set(authenticated);
+  return {
+    getAll: () => models,
+    hasConfiguredAuth: (candidate: unknown) => authenticatedModels.has(candidate),
+  };
 }
 
 function expectSubagentResult(
@@ -167,6 +183,7 @@ function event(value: Record<string, unknown>): AgentSessionEvent {
 
 class FakeForkSessionManager {
   public branchedFrom: string | undefined;
+  public modelChanges: Array<{ provider: string; modelId: string }> = [];
 
   constructor(
     private readonly cwd: string,
@@ -177,9 +194,13 @@ class FakeForkSessionManager {
 
   getSessionFile() { return this.sessionFile; }
   getCwd() { return this.cwd; }
-  getSessionId() { return `session:${path.basename(this.sessionFile)}`; }
+  getSessionId() { return "fork-session-id"; }
   getLeafId() { return this.branchedFrom ?? "fork-leaf"; }
   getBranch() { return []; }
+  appendModelChange(provider: string, modelId: string) {
+    this.modelChanges.push({ provider, modelId });
+    return "model-change";
+  }
 
   createBranchedSession(leafId: string) {
     this.branchedFrom = leafId;
@@ -789,7 +810,7 @@ describe("subagent runner", () => {
     const cwd = path.join(root, "project");
     const agentPath = path.join(cwd, ".pi", "agents", "reviewer.md");
     await mkdir(path.dirname(agentPath), { recursive: true });
-    await writeFile(agentPath, "---\ndescription: Reviews\nagentsMd: auto\nskills: none\n---\n\nFresh reviewer body.\n", "utf8");
+    await writeFile(agentPath, "---\ndescription: Reviews\nmodel: zai/new-reviewer-model\nagentsMd: auto\nskills: none\n---\n\nFresh reviewer body.\n", "utf8");
     const parentSession = path.join(root, "sessions", "parent.jsonl");
     const childSession = path.join(`${parentSession}.subagents`, "child.jsonl");
     const oldAgentPath = path.join(root, "old-agents", "reviewer.md");
@@ -806,6 +827,8 @@ describe("subagent runner", () => {
     expect(loaderOptions).toMatchObject({ cwd, agentDir: path.join(root, "agent"), noSkills: true });
     expect(loaderOptions?.noContextFiles).toBeUndefined();
     expect(loaderOptions?.appendSystemPromptOverride).toBeUndefined();
+    const sessionCalls = (deps.createAgentSession as unknown as { mock: { calls: Array<[Record<string, unknown>]> } }).mock.calls;
+    expect(sessionCalls[0]?.[0]).not.toHaveProperty("model");
     const manifest = await readManifestRecords(`${parentSession}.subagents/manifest.jsonl`);
     expect(manifest).toContainEqual(expect.objectContaining({ type: "resume_started", episodeId: "run-1", sessionId: "named-fresh-session", agentFile: agentPath }));
     expect(manifest).not.toContainEqual(expect.objectContaining({ type: "resume_started", agentFile: oldAgentPath }));
@@ -1015,8 +1038,9 @@ describe("subagent runner", () => {
     const { deps, fakeSession } = fakeDeps(root);
     const updates: unknown[] = [];
     const createSettingsManager = vi.spyOn(SettingsManager, "create");
+    const parentModel = fakeModel("zai", "glm-5");
 
-    const result = await runSubagent({ task: "answer briefly" }, undefined, (partial) => updates.push(partial), fakeContext(cwd, parentSession), { deps });
+    const result = await runSubagent({ task: "answer briefly" }, undefined, (partial) => updates.push(partial), fakeContext(cwd, parentSession, { model: parentModel }), { deps });
 
     expect(fakeSession.promptedWith).toBe(expectedPromptEnvelope("fresh", "answer briefly"));
     expectSubagentResult(result);
@@ -1039,6 +1063,92 @@ describe("subagent runner", () => {
     expect(createSettingsManager).toHaveBeenCalledWith(cwd, path.join(root, "agent"), { projectTrusted: true });
     expectProjectTrustedSettingsManager(loaderOptions?.settingsManager);
     expect(sessionOptions?.settingsManager).toBe(loaderOptions?.settingsManager);
+    expect(sessionOptions?.model).toBe(parentModel);
+  });
+
+  it("uses a named agent's default model for a fresh child", async () => {
+    const root = await tempRoot();
+    const cwd = path.join(root, "project");
+    const agentPath = path.join(cwd, ".pi", "agents", "vision.md");
+    await mkdir(path.dirname(agentPath), { recursive: true });
+    await writeFile(agentPath, "---\ndescription: Reads images\nmodel: zai/glm-5v-turbo\n---\n\nRead the image.\n", "utf8");
+    const parentSession = path.join(root, "sessions", "parent.jsonl");
+    const visionModel = fakeModel("zai", "glm-5v-turbo");
+    const { deps } = fakeDeps(root);
+
+    await runSubagent(
+      { agent: "vision", task: "read screenshot.png" },
+      undefined,
+      undefined,
+      fakeContext(cwd, parentSession, { modelRegistry: fakeModelRegistry([visionModel]) }),
+      { deps },
+    );
+
+    const sessionOptions = (deps.createAgentSession as unknown as { mock: { calls: Array<[Record<string, unknown>]> } }).mock.calls[0]?.[0];
+    expect(sessionOptions?.model).toBe(visionModel);
+  });
+
+  it("lets a call-level model override a named agent default", async () => {
+    const root = await tempRoot();
+    const cwd = path.join(root, "project");
+    const agentPath = path.join(cwd, ".pi", "agents", "vision.md");
+    await mkdir(path.dirname(agentPath), { recursive: true });
+    await writeFile(agentPath, "---\ndescription: Reads images\nmodel: unavailable/default\n---\n\nRead the image.\n", "utf8");
+    const parentSession = path.join(root, "sessions", "parent.jsonl");
+    const overrideModel = fakeModel("zai", "glm-5v-turbo");
+    const { deps } = fakeDeps(root);
+
+    await runSubagent(
+      { agent: "vision", task: "read screenshot.png", model: "zai/glm-5v-turbo" },
+      undefined,
+      undefined,
+      fakeContext(cwd, parentSession, { modelRegistry: fakeModelRegistry([overrideModel]) }),
+      { deps },
+    );
+
+    const sessionOptions = (deps.createAgentSession as unknown as { mock: { calls: Array<[Record<string, unknown>]> } }).mock.calls[0]?.[0];
+    expect(sessionOptions?.model).toBe(overrideModel);
+  });
+
+  it("supports a call-level model in omitted-agent mode", async () => {
+    const root = await tempRoot();
+    const cwd = path.join(root, "project");
+    await mkdir(cwd, { recursive: true });
+    const parentSession = path.join(root, "sessions", "parent.jsonl");
+    const visionModel = fakeModel("zai", "glm-5v-turbo");
+    const { deps } = fakeDeps(root);
+
+    await runSubagent(
+      { task: "read screenshot.png", model: "glm-5v-turbo" },
+      undefined,
+      undefined,
+      fakeContext(cwd, parentSession, { modelRegistry: fakeModelRegistry([visionModel]) }),
+      { deps },
+    );
+
+    const sessionOptions = (deps.createAgentSession as unknown as { mock: { calls: Array<[Record<string, unknown>]> } }).mock.calls[0]?.[0];
+    expect(sessionOptions?.model).toBe(visionModel);
+  });
+
+  it("rejects an unknown explicit model before creating child artifacts", async () => {
+    const root = await tempRoot();
+    const cwd = path.join(root, "project");
+    await mkdir(cwd, { recursive: true });
+    const parentSession = path.join(root, "sessions", "parent.jsonl");
+    const { deps } = fakeDeps(root);
+
+    const message = await rejectedMessage(runSubagent(
+      { task: "read screenshot.png", model: "missing-model" },
+      undefined,
+      undefined,
+      fakeContext(cwd, parentSession, { modelRegistry: fakeModelRegistry([]) }),
+      { deps },
+    ));
+
+    expect(message).toContain("Subagent model 'missing-model' not found");
+    expectNoRecoveryHandle(message);
+    expect(deps.createFreshSessionManager).not.toHaveBeenCalled();
+    await expect(readdir(`${parentSession}.subagents`)).rejects.toThrow();
   });
 
   it("streams child activity as portable partial updates and append-only activity-log entries", async () => {
@@ -1332,6 +1442,98 @@ describe("subagent runner", () => {
     expect(result.details.run).toMatchObject({ episodeId: "resume-1", sessionId, status: "completed" });
   });
 
+  it("preserves the inherited model across an early fresh failure and resume", async () => {
+    const root = await tempRoot();
+    const cwd = path.join(root, "project");
+    await mkdir(cwd, { recursive: true });
+    const parentSession = path.join(root, "sessions", "parent.jsonl");
+    const inheritedModel = fakeModel("zai", "glm-5v-turbo");
+    const failed = fakeDeps(root);
+    failed.deps.createAgentSession = vi.fn(async () => { throw new Error("sdk failed before recording model"); });
+
+    const message = await rejectedMessage(runSubagent(
+      { task: "fail early" },
+      undefined,
+      undefined,
+      fakeContext(cwd, parentSession, { model: inheritedModel }),
+      { deps: failed.deps },
+    ));
+
+    const manifestAfterFailure = await readManifestRecords(`${parentSession}.subagents/manifest.jsonl`);
+    const started = manifestAfterFailure[0]?.type === "started" ? manifestAfterFailure[0] : undefined;
+    expect(started).toBeDefined();
+    expectRecoverableFailure(message, started!.sessionId, "sdk failed before recording model");
+    const childEntries = (await readFile(started!.sessionFile, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(childEntries).toContainEqual(expect.objectContaining({
+      type: "model_change",
+      provider: "zai",
+      modelId: "glm-5v-turbo",
+    }));
+
+    const resumed = fakeDeps(root);
+    resumed.deps.createEpisodeId = vi.fn(() => "resume-1");
+    resumed.deps.createAgentSession = vi.fn(async (options: { sessionManager: SessionManager }) => ({
+      session: new FakeChildSession({
+        promptImpl: async (text) => {
+          options.sessionManager.appendMessage({ role: "user", content: [{ type: "text", text }], timestamp: Date.now() } as Parameters<SessionManager["appendMessage"]>[0]);
+          options.sessionManager.appendMessage({ role: "assistant", content: [{ type: "text", text: "child answer" }], stopReason: "stop", timestamp: Date.now() } as Parameters<SessionManager["appendMessage"]>[0]);
+        },
+      }) as unknown as AgentSession,
+    }));
+    const result = await runSubagentResume(
+      { sessionId: started!.sessionId, message: "continue" },
+      undefined,
+      undefined,
+      fakeContext(cwd, parentSession, { modelRegistry: fakeModelRegistry([inheritedModel]) }),
+      { deps: resumed.deps },
+    );
+
+    expectSubagentResult(result);
+    const sessionOptions = (resumed.deps.createAgentSession as unknown as { mock: { calls: Array<[Record<string, unknown>]> } }).mock.calls[0]?.[0];
+    expect(sessionOptions?.model).toBe(inheritedModel);
+  });
+
+  it("does not overwrite a child's model change during failure cleanup", async () => {
+    const root = await tempRoot();
+    const cwd = path.join(root, "project");
+    await mkdir(cwd, { recursive: true });
+    const parentSession = path.join(root, "sessions", "parent.jsonl");
+    const inheritedModel = fakeModel("zai", "glm-5v-turbo");
+    const { deps } = fakeDeps(root);
+    deps.createAgentSession = vi.fn(async (options: { sessionManager: SessionManager }) => {
+      options.sessionManager.appendModelChange("openai", "gpt-5");
+      return {
+        session: new FakeChildSession({
+          promptImpl: async () => { throw new Error("failed after model switch"); },
+        }) as unknown as AgentSession,
+      };
+    });
+
+    const message = await rejectedMessage(runSubagent(
+      { task: "switch then fail" },
+      undefined,
+      undefined,
+      fakeContext(cwd, parentSession, { model: inheritedModel }),
+      { deps },
+    ));
+
+    const manifest = await readManifestRecords(`${parentSession}.subagents/manifest.jsonl`);
+    const started = manifest[0]?.type === "started" ? manifest[0] : undefined;
+    expect(started).toBeDefined();
+    expectRecoverableFailure(message, started!.sessionId, "failed after model switch");
+    const modelChanges = (await readFile(started!.sessionFile, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>)
+      .filter((entry) => entry.type === "model_change");
+    expect(modelChanges).toEqual([
+      expect.objectContaining({ provider: "openai", modelId: "gpt-5" }),
+    ]);
+  });
+
   it("records a failed run when child session creation fails after artifacts start", async () => {
     const root = await tempRoot();
     const cwd = path.join(root, "project");
@@ -1615,6 +1817,60 @@ describe("subagent runner", () => {
 
     const manifest = await readManifestRecords(`${parentSession}.subagents/manifest.jsonl`);
     expect(manifest[0]).toMatchObject({ type: "started", episodeId: "run-1", parentEpisodeId: null, agent: "subagent", agentFile: null, cwd, context: "fork", sessionFile: childSession });
+  });
+
+  it("persists an explicit fork model for later resume", async () => {
+    const root = await tempRoot();
+    const cwd = path.join(root, "project");
+    await mkdir(cwd, { recursive: true });
+    const parentSession = path.join(root, "sessions", "parent.jsonl");
+    const forkManager = new FakeForkSessionManager(cwd, parentSession);
+    const visionModel = fakeModel("zai", "glm-5v-turbo");
+    const { deps } = fakeDeps(root);
+    deps.openSessionManager = vi.fn(() => forkManager as unknown as SessionManager);
+
+    await runSubagent(
+      { task: "inspect the branch", context: "fork", model: "zai/glm-5v-turbo" },
+      undefined,
+      undefined,
+      fakeContext(cwd, parentSession, {
+        leafId: "leaf-current",
+        modelRegistry: fakeModelRegistry([visionModel]),
+      }),
+      { deps },
+    );
+
+    const sessionOptions = (deps.createAgentSession as unknown as { mock: { calls: Array<[Record<string, unknown>]> } }).mock.calls[0]?.[0];
+    expect(sessionOptions?.model).toBe(visionModel);
+    expect(forkManager.modelChanges).toEqual([{ provider: "zai", modelId: "glm-5v-turbo" }]);
+  });
+
+  it("rejects an SDK model fallback before prompting the child", async () => {
+    const root = await tempRoot();
+    const cwd = path.join(root, "project");
+    await mkdir(cwd, { recursive: true });
+    const parentSession = path.join(root, "sessions", "parent.jsonl");
+    const forkManager = new FakeForkSessionManager(cwd, parentSession);
+    const { deps, fakeSession } = fakeDeps(root);
+    deps.openSessionManager = vi.fn(() => forkManager as unknown as SessionManager);
+    deps.createAgentSession = vi.fn(async () => ({
+      session: fakeSession as unknown as AgentSession,
+      modelFallbackMessage: "Could not restore model zai/glm-5v-turbo. Using openai/gpt-5",
+    }));
+
+    const message = await rejectedMessage(runSubagent(
+      { task: "inspect the branch", context: "fork" },
+      undefined,
+      undefined,
+      fakeContext(cwd, parentSession, { leafId: "leaf-current" }),
+      { deps },
+    ));
+
+    const manifest = await readManifestRecords(`${parentSession}.subagents/manifest.jsonl`);
+    const sessionId = manifest[0]?.type === "started" ? manifest[0].sessionId : "";
+    expectRecoverableFailure(message, sessionId, "Could not restore model zai/glm-5v-turbo. Using openai/gpt-5");
+    expect(fakeSession.promptCount).toBe(0);
+    expect(fakeSession.disposeCount).toBe(1);
   });
 
   it("runs named-agent fork prompt envelopes without fresh resource overrides or model overrides", async () => {

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -216,6 +216,7 @@ interface FakeChildSessionOptions {
   messages?: unknown[];
   promptImpl?: (text: string) => Promise<void>;
   bindImpl?: () => Promise<void>;
+  shutdownImpl?: () => Promise<void>;
   abortImpl?: () => Promise<void>;
   unsubscribeImpl?: () => void;
   disposeImpl?: () => void;
@@ -260,12 +261,15 @@ class FakeChildSession {
   public promptCount = 0;
   public abortCount = 0;
   public disposeCount = 0;
+  public shutdownCount = 0;
+  public shutdownEvents: unknown[] = [];
   public unsubscribeCount = 0;
   public contextUsageCallCount = 0;
   public messages: unknown[] = [];
   private readonly lastAssistantText: string | undefined;
   private readonly promptImpl: (text: string) => Promise<void>;
   private readonly bindImpl: () => Promise<void>;
+  private readonly shutdownImpl: () => Promise<void>;
   private readonly abortImpl: () => Promise<void>;
   private readonly unsubscribeImpl: () => void;
   private readonly disposeImpl: () => void;
@@ -280,6 +284,7 @@ class FakeChildSession {
     this.messagesAfterPrompt = options.messages ?? [{ role: "assistant", stopReason: "stop", content: [{ type: "text", text: this.lastAssistantText }] }];
     this.promptImpl = options.promptImpl ?? (async () => undefined);
     this.bindImpl = options.bindImpl ?? (async () => undefined);
+    this.shutdownImpl = options.shutdownImpl ?? (async () => undefined);
     this.abortImpl = options.abortImpl ?? (async () => undefined);
     this.unsubscribeImpl = options.unsubscribeImpl ?? (() => undefined);
     this.disposeImpl = options.disposeImpl ?? (() => undefined);
@@ -322,6 +327,20 @@ class FakeChildSession {
     await this.bindImpl();
   }
 
+  hasExtensionHandlers(eventType: string) {
+    return eventType === "session_shutdown";
+  }
+
+  get extensionRunner() {
+    return {
+      emit: async (event: unknown) => {
+        this.shutdownCount += 1;
+        this.shutdownEvents.push(event);
+        await this.shutdownImpl();
+      },
+    };
+  }
+
   async abort() {
     this.abortCount += 1;
     this.aborted = true;
@@ -359,6 +378,7 @@ describe("subagent runner", () => {
     expect(deps.openSessionManager).toHaveBeenCalledWith(childSession, `${parentSession}.subagents`);
     expect(deps.createFreshSessionManager).not.toHaveBeenCalled();
     expect(fakeSession.promptedWith).toBe("continue from there");
+    expect(fakeSession.shutdownEvents).toEqual([{ type: "session_shutdown", reason: "quit" }]);
     expectSubagentResult(result);
     expect(result.details.run).toMatchObject({ episodeId: "resume-1", sessionId: "child-session-1", agent: "subagent", status: "completed" });
     const activityText = await readFile(`${parentSession}.subagents.md`, "utf8");
@@ -1560,6 +1580,25 @@ describe("subagent runner", () => {
     expect(activityText).toContain("failed subagent — 0 turns — error: sdk session failed — session:");
   });
 
+  it("shuts down bound child extensions before disposing the session", async () => {
+    const root = await tempRoot();
+    const cwd = path.join(root, "project");
+    await mkdir(cwd, { recursive: true });
+    const parentSession = path.join(root, "sessions", "parent.jsonl");
+    const lifecycle: string[] = [];
+    const { deps, fakeSession } = fakeDeps(root, {
+      bindImpl: async () => { lifecycle.push("bind"); },
+      shutdownImpl: async () => { lifecycle.push("shutdown"); },
+      disposeImpl: () => { lifecycle.push("dispose"); },
+    });
+
+    const result = await runSubagent({ task: "lifecycle" }, undefined, undefined, fakeContext(cwd, parentSession), { deps });
+
+    expectSubagentResult(result);
+    expect(lifecycle).toEqual(["bind", "shutdown", "dispose"]);
+    expect(fakeSession.shutdownEvents).toEqual([{ type: "session_shutdown", reason: "quit" }]);
+  });
+
   it("disposes a child session when extension binding fails", async () => {
     const root = await tempRoot();
     const cwd = path.join(root, "project");
@@ -1586,6 +1625,7 @@ describe("subagent runner", () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
     const { deps, fakeSession } = fakeDeps(root, {
       promptImpl: async () => { throw new Error("primary failure"); },
+      shutdownImpl: async () => { throw new Error("shutdown failed"); },
       unsubscribeImpl: () => { throw new Error("unsubscribe failed"); },
       disposeImpl: () => { throw new Error("dispose failed"); },
     });
@@ -1593,8 +1633,10 @@ describe("subagent runner", () => {
     await expect(runSubagent({ task: "cleanup failure" }, undefined, undefined, fakeContext(cwd, parentSession), { deps })).rejects.toThrow("primary failure");
 
     expect(fakeSession.unsubscribeCount).toBe(1);
+    expect(fakeSession.shutdownCount).toBe(1);
     expect(fakeSession.disposeCount).toBe(1);
     expect(consoleError).toHaveBeenCalledWith(expect.stringContaining("unsubscribe subagent activity listener"), expect.any(Error));
+    expect(consoleError).toHaveBeenCalledWith(expect.stringContaining("shut down subagent child extensions"), expect.any(Error));
     expect(consoleError).toHaveBeenCalledWith(expect.stringContaining("dispose subagent child session"), expect.any(Error));
     consoleError.mockRestore();
   });

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { SessionManager, SettingsManager, type AgentSession, type AgentSessionEvent, type ExtensionContext, type ResourceLoader } from "@earendil-works/pi-coding-agent";
+import { SessionManager, SettingsManager, type AgentSession, type AgentSessionEvent, type CreateAgentSessionOptions, type ExtensionContext, type ResourceLoader } from "@earendil-works/pi-coding-agent";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { readManifestRecords } from "../src/manifest.js";
 import { runSubagent, runSubagentResume } from "../src/runner.js";
@@ -218,6 +218,7 @@ interface FakeChildSessionOptions {
   bindImpl?: () => Promise<void>;
   shutdownImpl?: () => Promise<void>;
   abortImpl?: () => Promise<void>;
+  persistPromptWithModel?: { provider: string; modelId: string };
   unsubscribeImpl?: () => void;
   disposeImpl?: () => void;
   events?: AgentSessionEvent[];
@@ -248,7 +249,10 @@ function fakeDeps(root: string, session?: FakeChildSessionOptions) {
         getAppendSystemPrompt: vi.fn(),
         extendResources: vi.fn(),
       } as unknown as ResourceLoader)),
-      createAgentSession: vi.fn(async () => ({ session: fakeSession as unknown as AgentSession })),
+      createAgentSession: vi.fn(async (options: CreateAgentSessionOptions) => {
+        fakeSession.setSessionManager(options.sessionManager);
+        return { session: fakeSession as unknown as AgentSession };
+      }),
     },
   };
 }
@@ -271,11 +275,13 @@ class FakeChildSession {
   private readonly bindImpl: () => Promise<void>;
   private readonly shutdownImpl: () => Promise<void>;
   private readonly abortImpl: () => Promise<void>;
+  private readonly persistPromptWithModel: { provider: string; modelId: string } | undefined;
   private readonly unsubscribeImpl: () => void;
   private readonly disposeImpl: () => void;
   private readonly getContextUsageImpl: () => SubagentContextUsage | undefined;
   private readonly events: AgentSessionEvent[];
   private readonly messagesAfterPrompt: unknown[];
+  private sessionManager: SessionManager | undefined;
   private listeners: Array<(event: AgentSessionEvent) => void> = [];
 
   constructor(options: FakeChildSessionOptions = {}) {
@@ -286,6 +292,7 @@ class FakeChildSession {
     this.bindImpl = options.bindImpl ?? (async () => undefined);
     this.shutdownImpl = options.shutdownImpl ?? (async () => undefined);
     this.abortImpl = options.abortImpl ?? (async () => undefined);
+    this.persistPromptWithModel = options.persistPromptWithModel;
     this.unsubscribeImpl = options.unsubscribeImpl ?? (() => undefined);
     this.disposeImpl = options.disposeImpl ?? (() => undefined);
     this.getContextUsageImpl = options.getContextUsageImpl ?? (() => options.contextUsage);
@@ -297,7 +304,21 @@ class FakeChildSession {
     this.promptedWith = text;
     for (const event of this.events) this.emit(event);
     await this.promptImpl(text);
+    if (this.persistPromptWithModel && this.sessionManager) {
+      this.sessionManager.appendMessage({ role: "user", content: text } as Parameters<SessionManager["appendMessage"]>[0]);
+      this.sessionManager.appendMessage({
+        role: "assistant",
+        provider: this.persistPromptWithModel.provider,
+        model: this.persistPromptWithModel.modelId,
+        content: [{ type: "text", text: this.lastAssistantText }],
+        stopReason: "stop",
+      } as unknown as Parameters<SessionManager["appendMessage"]>[0]);
+    }
     this.messages.push(...this.messagesAfterPrompt);
+  }
+
+  setSessionManager(sessionManager: SessionManager | undefined) {
+    this.sessionManager = sessionManager;
   }
 
   emit(event: AgentSessionEvent) {
@@ -902,8 +923,14 @@ describe("subagent runner", () => {
     await writeChildSessionHeader(childSession, "abort-resume-session", cwd);
     await writeManifestRecord(parentSession, startedManifestRecord({ sessionId: "abort-resume-session", cwd, sessionFile: childSession }));
     const abortController = new AbortController();
+    const lifecycle: string[] = [];
     const { deps, fakeSession } = fakeDeps(root, {
       promptImpl: async () => new Promise<void>(() => undefined),
+      abortImpl: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        lifecycle.push("abort");
+      },
+      disposeImpl: () => { lifecycle.push("dispose"); },
     });
     deps.createEpisodeId = vi.fn(() => "resume-1");
     const updates: unknown[] = [];
@@ -917,6 +944,7 @@ describe("subagent runner", () => {
     expect(fakeSession.abortCount).toBe(1);
     expect(fakeSession.unsubscribeCount).toBe(1);
     expect(fakeSession.disposeCount).toBe(1);
+    expect(lifecycle).toEqual(["abort", "dispose"]);
     expect(updates.at(-1)).toMatchObject({ details: { run: { episodeId: "resume-1", sessionId: "abort-resume-session", status: "aborted", activity: "interrupted" } } });
     const manifest = await readManifestRecords(`${parentSession}.subagents/manifest.jsonl`);
     expect(manifest.at(-1)).toMatchObject({ type: "resume_finished", episodeId: "resume-1", sessionId: "abort-resume-session", status: "aborted", error: "Interrupted by parent abort." });
@@ -1746,7 +1774,15 @@ describe("subagent runner", () => {
     await mkdir(cwd, { recursive: true });
     const parentSession = path.join(root, "sessions", "parent.jsonl");
     const abortController = new AbortController();
-    const { deps, fakeSession } = fakeDeps(root, { promptImpl: async () => { abortController.abort(); } });
+    const lifecycle: string[] = [];
+    const { deps, fakeSession } = fakeDeps(root, {
+      promptImpl: async () => { abortController.abort(); },
+      abortImpl: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        lifecycle.push("abort");
+      },
+      disposeImpl: () => { lifecycle.push("dispose"); },
+    });
 
     const message = await rejectedMessage(runSubagent({ task: "abortable" }, abortController.signal, undefined, fakeContext(cwd, parentSession), { deps }));
     const manifest = await readManifestRecords(`${parentSession}.subagents/manifest.jsonl`);
@@ -1756,6 +1792,7 @@ describe("subagent runner", () => {
     expect(fakeSession.abortCount).toBe(1);
     expect(fakeSession.unsubscribeCount).toBe(1);
     expect(fakeSession.disposeCount).toBe(1);
+    expect(lifecycle).toEqual(["abort", "dispose"]);
   });
 
   it("does not prompt a child if the parent aborts after session creation but before prompting", async () => {
@@ -1898,30 +1935,57 @@ describe("subagent runner", () => {
     expect(manifest[0]).toMatchObject({ type: "started", episodeId: "run-1", parentEpisodeId: null, agent: "subagent", agentFile: null, cwd, context: "fork", sessionFile: childSession });
   });
 
-  it("persists an explicit fork model for later resume", async () => {
+  it("persists a named fork model and restores it on resume after the agent default changes", async () => {
     const root = await tempRoot();
     const cwd = path.join(root, "project");
-    await mkdir(cwd, { recursive: true });
-    const parentSession = path.join(root, "sessions", "parent.jsonl");
-    const forkManager = new FakeForkSessionManager(cwd, parentSession);
+    const agentPath = path.join(cwd, ".pi", "agents", "vision.md");
+    await mkdir(path.dirname(agentPath), { recursive: true });
+    await writeFile(agentPath, "---\ndescription: Inspects images\nmodel: zai/glm-5v-turbo\nagentsMd: none\nskills: none\n---\n\nInspect carefully.\n", "utf8");
+    const parentManager = SessionManager.create(cwd, path.join(root, "sessions"));
+    parentManager.appendMessage({ role: "user", content: "Inspect this branch." } as Parameters<SessionManager["appendMessage"]>[0]);
+    parentManager.appendMessage({ role: "assistant", content: [{ type: "text", text: "Ready." }], stopReason: "stop" } as unknown as Parameters<SessionManager["appendMessage"]>[0]);
+    const parentSession = parentManager.getSessionFile();
+    if (!parentSession) throw new Error("expected persisted parent session");
     const visionModel = fakeModel("zai", "glm-5v-turbo");
-    const { deps } = fakeDeps(root);
-    deps.openSessionManager = vi.fn(() => forkManager as unknown as SessionManager);
+    const laterDefault = fakeModel("openai", "gpt-5");
+    const registry = fakeModelRegistry([visionModel, laterDefault]);
+    const initial = fakeDeps(root, {
+      persistPromptWithModel: { provider: "zai", modelId: "glm-5v-turbo" },
+    });
 
     await runSubagent(
-      { task: "inspect the branch", context: "fork", model: "zai/glm-5v-turbo" },
+      { agent: "vision", task: "inspect the branch", context: "fork" },
       undefined,
       undefined,
       fakeContext(cwd, parentSession, {
-        leafId: "leaf-current",
-        modelRegistry: fakeModelRegistry([visionModel]),
+        leafId: parentManager.getLeafId(),
+        modelRegistry: registry,
       }),
-      { deps },
+      { deps: initial.deps },
     );
 
-    const sessionOptions = (deps.createAgentSession as unknown as { mock: { calls: Array<[Record<string, unknown>]> } }).mock.calls[0]?.[0];
+    const manifest = await readManifestRecords(`${parentSession}.subagents/manifest.jsonl`);
+    const started = manifest[0]?.type === "started" ? manifest[0] : undefined;
+    expect(started).toBeDefined();
+    const persisted = SessionManager.open(started!.sessionFile, `${parentSession}.subagents`).buildSessionContext().model;
+    expect(persisted).toEqual({ provider: "zai", modelId: "glm-5v-turbo" });
+
+    await writeFile(agentPath, "---\ndescription: Inspects images\nmodel: openai/gpt-5\nagentsMd: none\nskills: none\n---\n\nInspect carefully.\n", "utf8");
+    const resumed = fakeDeps(root, {
+      persistPromptWithModel: { provider: "zai", modelId: "glm-5v-turbo" },
+    });
+    resumed.deps.createEpisodeId = vi.fn(() => "resume-1");
+    const result = await runSubagentResume(
+      { sessionId: started!.sessionId, message: "continue the inspection" },
+      undefined,
+      undefined,
+      fakeContext(cwd, parentSession, { modelRegistry: registry }),
+      { deps: resumed.deps },
+    );
+
+    expectSubagentResult(result, "## Subagent vision result");
+    const sessionOptions = (resumed.deps.createAgentSession as unknown as { mock: { calls: Array<[Record<string, unknown>]> } }).mock.calls[0]?.[0];
     expect(sessionOptions?.model).toBe(visionModel);
-    expect(forkManager.modelChanges).toEqual([{ provider: "zai", modelId: "glm-5v-turbo" }]);
   });
 
   it("rejects an SDK model fallback before prompting the child", async () => {

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -1468,6 +1468,12 @@ describe("subagent runner", () => {
     await mkdir(cwd, { recursive: true });
     const parentSession = path.join(root, "sessions", "parent.jsonl");
     const inheritedModel = fakeModel("zai", "glm-5v-turbo");
+    const laterParentModel = fakeModel("openai", "gpt-5");
+    const readParentModel = vi.fn()
+      .mockReturnValueOnce(inheritedModel)
+      .mockReturnValue(laterParentModel);
+    const context = fakeContext(cwd, parentSession);
+    Object.defineProperty(context, "model", { get: readParentModel });
     const failed = fakeDeps(root);
     failed.deps.createAgentSession = vi.fn(async () => { throw new Error("sdk failed before recording model"); });
 
@@ -1475,9 +1481,11 @@ describe("subagent runner", () => {
       { task: "fail early" },
       undefined,
       undefined,
-      fakeContext(cwd, parentSession, { model: inheritedModel }),
+      context,
       { deps: failed.deps },
     ));
+
+    expect(readParentModel).toHaveBeenCalledTimes(1);
 
     const manifestAfterFailure = await readManifestRecords(`${parentSession}.subagents/manifest.jsonl`);
     const started = manifestAfterFailure[0]?.type === "started" ? manifestAfterFailure[0] : undefined;
@@ -1597,6 +1605,35 @@ describe("subagent runner", () => {
     expectSubagentResult(result);
     expect(lifecycle).toEqual(["bind", "shutdown", "dispose"]);
     expect(fakeSession.shutdownEvents).toEqual([{ type: "session_shutdown", reason: "quit" }]);
+  });
+
+  it("keeps the child session reserved until extension shutdown finishes", async () => {
+    const root = await tempRoot();
+    const cwd = path.join(root, "project");
+    await mkdir(cwd, { recursive: true });
+    const parentSession = path.join(root, "sessions", "parent.jsonl");
+    const resumed = fakeDeps(root);
+    let resumeAttempt: Promise<unknown> | undefined;
+    let sessionId = "";
+    const { deps } = fakeDeps(root, {
+      shutdownImpl: async () => {
+        const manifest = await readManifestRecords(`${parentSession}.subagents/manifest.jsonl`);
+        sessionId = manifest[0]?.type === "started" ? manifest[0].sessionId : "";
+        resumeAttempt = runSubagentResume(
+          { sessionId, message: "resume during shutdown" },
+          undefined,
+          undefined,
+          fakeContext(cwd, parentSession),
+          { deps: resumed.deps },
+        );
+        await resumeAttempt.catch(() => undefined);
+      },
+    });
+
+    await runSubagent({ task: "finish before shutdown" }, undefined, undefined, fakeContext(cwd, parentSession), { deps });
+
+    expect(resumeAttempt).toBeDefined();
+    await expect(resumeAttempt).rejects.toThrow(`Subagent session '${sessionId}' is already active`);
   });
 
   it("disposes a child session when extension binding fails", async () => {


### PR DESCRIPTION
## Summary

- let named agents declare a default model in frontmatter
- let each `subagent` call override that model explicitly
- snapshot and preserve the chosen model across failures and resumes, without silent fallback
- shut down child extensions before disposal, keep sessions reserved through teardown, and await child abort settlement
- replace the reviewer documentation example with a Vision agent using `glm-5v-turbo`

## Validation

- `npm test` — 183 tests
- `npm run typecheck`
- `npm run build`
- `npm run smoke:registration`
- `npm pack --dry-run`
- rebased onto current `main` and verified model selection with the unified XML prompt envelopes
- real Pi 0.83 QA in tmux covered frontmatter defaults, canonical and bare call overrides, fresh/fork isolation, fresh and fork resume, omitted-agent inheritance, discovery, and durable manifests
- unknown and unauthenticated models failed before creating artifacts or continuation handles
- reproduced and fixed an ambient child-extension teardown crash; the exact real-Pi setup remained alive after the fix
- interrupted a real child during a long-running bash command, verified abort settlement and process cleanup, then resumed the same recorded model/session successfully
- verified the documented fork prompt-collision caveat, then reran the fork without conflicting parent instructions successfully
